### PR TITLE
feat: subscriptions refinements and comments

### DIFF
--- a/examples/authResolvers.js
+++ b/examples/authResolvers.js
@@ -41,7 +41,6 @@ const resolvers = {
   }
 }
 
-// Initialize the voyager server with our schema and context
 const options ={
   typeDefs: [KeycloakTypeDefs, typeDefs],
   resolvers,

--- a/examples/authResolvers.js
+++ b/examples/authResolvers.js
@@ -1,40 +1,19 @@
-const fs = require('fs')
-const path = require('path')
 const express = require('express')
-const session = require('express-session')
-const Keycloak = require('keycloak-connect')
 const { ApolloServer, gql } = require('apollo-server-express')
+const { configureKeycloak } = require('./common')
 
-const { KeycloakContext, KeycloakTypeDefs, auth, hasRole } = require('../')
+const {
+  KeycloakContext,
+  KeycloakTypeDefs,
+  KeycloakSchemaDirectives
+} = require('../')
 
 const app = express()
 
-const memoryStore = new session.MemoryStore()
-
 const graphqlPath = '/graphql'
 
-
-app.use(session({
-  secret: process.env.SESSION_SECRET_STRING || 'this should be a long secret',
-  resave: false,
-  saveUninitialized: true,
-  store: memoryStore
-}))
-
-const keycloakConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, './config/keycloak.json')))
-
-const keycloak = new Keycloak({
-  store: memoryStore
-}, keycloakConfig)
-
-// Install general keycloak middleware
-app.use(keycloak.middleware({
-  admin: graphqlPath
-}))
-
-// Protect the main route for all graphql services
-// Disable unauthenticated access
-app.use(graphqlPath, keycloak.middleware())
+// perform the standard keycloak-connect middleware setup on our app
+configureKeycloak(app, graphqlPath)
 
 const typeDefs = gql`
   type Query {

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,41 +1,19 @@
-const fs = require('fs')
-const path = require('path')
 const express = require('express')
-const session = require('express-session')
-const Keycloak = require('keycloak-connect')
-
-const { KeycloakContext, KeycloakTypeDefs, KeycloakSchemaDirectives } = require('../')
-
 const { ApolloServer, gql } = require('apollo-server-express')
+const { configureKeycloak } = require('./common')
 
-const keycloakConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, './config/keycloak.json')))
+const {
+  KeycloakContext,
+  KeycloakTypeDefs,
+  KeycloakSchemaDirectives
+} = require('../')
 
 const app = express()
 
-const memoryStore = new session.MemoryStore()
-
 const graphqlPath = '/graphql'
 
-
-app.use(session({
-  secret: process.env.SESSION_SECRET_STRING || 'this should be a long secret',
-  resave: false,
-  saveUninitialized: true,
-  store: memoryStore
-}))
-
-const keycloak = new Keycloak({
-  store: memoryStore
-}, keycloakConfig)
-
-// Install general keycloak middleware
-app.use(keycloak.middleware({
-  admin: graphqlPath
-}))
-
-// Protect the main route for all graphql services
-// Disable unauthenticated access
-app.use(graphqlPath, keycloak.protect())
+// perform the standard keycloak-connect middleware setup on our app
+configureKeycloak(app, graphqlPath)
 
 const typeDefs = gql`
   type Query {

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -34,8 +34,6 @@ const resolvers = {
   }
 }
 
-// Initialize the voyager server with our schema and context
-
 const server = new ApolloServer({
   typeDefs: [KeycloakTypeDefs, typeDefs],
   schemaDirectives: KeycloakSchemaDirectives,

--- a/examples/common.js
+++ b/examples/common.js
@@ -1,0 +1,37 @@
+const fs = require('fs')
+const path = require('path')
+const session = require('express-session')
+const Keycloak = require('keycloak-connect')
+
+function configureKeycloak(app, graphqlPath) {
+
+  const keycloakConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, './config/keycloak.json')))
+
+  const memoryStore = new session.MemoryStore()
+
+  app.use(session({
+    secret: process.env.SESSION_SECRET_STRING || 'this should be a long secret',
+    resave: false,
+    saveUninitialized: true,
+    store: memoryStore
+  }))
+
+  const keycloak = new Keycloak({
+    store: memoryStore
+  }, keycloakConfig)
+
+  // Install general keycloak middleware
+  app.use(keycloak.middleware({
+    admin: graphqlPath
+  }))
+
+  // Protect the main route for all graphql services
+  // Disable unauthenticated access
+  app.use(graphqlPath, keycloak.middleware())
+
+  return { keycloak }
+}
+
+module.exports = {
+  configureKeycloak
+}

--- a/examples/private_and_public.js
+++ b/examples/private_and_public.js
@@ -41,7 +41,6 @@ const resolvers = {
   }
 }
 
-// Initialize the voyager server with our schema and context
 const options ={
   typeDefs: [KeycloakTypeDefs, typeDefs],
   schemaDirectives: KeycloakSchemaDirectives,

--- a/examples/private_and_public.js
+++ b/examples/private_and_public.js
@@ -1,40 +1,19 @@
-const fs = require('fs')
-const path = require('path')
 const express = require('express')
-const session = require('express-session')
-const Keycloak = require('keycloak-connect')
 const { ApolloServer, gql } = require('apollo-server-express')
+const { configureKeycloak } = require('./common')
 
-const { KeycloakContext, KeycloakTypeDefs, KeycloakSchemaDirectives } = require('../')
+const {
+  KeycloakContext,
+  KeycloakTypeDefs,
+  KeycloakSchemaDirectives
+} = require('../')
 
 const app = express()
 
-const memoryStore = new session.MemoryStore()
-
 const graphqlPath = '/graphql'
 
-
-app.use(session({
-  secret: process.env.SESSION_SECRET_STRING || 'this should be a long secret',
-  resave: false,
-  saveUninitialized: true,
-  store: memoryStore
-}))
-
-const keycloakConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, './config/keycloak.json')))
-
-const keycloak = new Keycloak({
-  store: memoryStore
-}, keycloakConfig)
-
-// Install general keycloak middleware
-app.use(keycloak.middleware({
-  admin: graphqlPath
-}))
-
-// Protect the main route for all graphql services
-// Disable unauthenticated access
-app.use(graphqlPath, keycloak.middleware())
+// perform the standard keycloak-connect middleware setup on our app
+configureKeycloak(app, graphqlPath)
 
 const typeDefs = gql`
   type Query {

--- a/examples/subscriptions.js
+++ b/examples/subscriptions.js
@@ -74,8 +74,6 @@ const httpServer = app.listen({ port }, () => {
   console.log(`🚀 Server ready at http://localhost:${port}${server.graphqlPath}`)
 
   // Initialize the keycloak subscription handler passing in our keycloak instance
-  // protect: false means that subscriptions will not fail
-  // if the token is not provided by the client in connectionParams
   const keycloakSubscriptionHandler = new KeycloakSubscriptionHandler({ keycloak })
   new SubscriptionServer({
     execute,

--- a/examples/subscriptions.js
+++ b/examples/subscriptions.js
@@ -55,14 +55,11 @@ const resolvers = {
   }
 }
 
-// Initialize the voyager server with our schema and context
-
 const server = new ApolloServer({
   typeDefs: [KeycloakTypeDefs, typeDefs],
   schemaDirectives: KeycloakSchemaDirectives,
   resolvers,
-  context: ({ req, connection }) => {
-    console.log(connection)
+  context: ({ req }) => {
     return {
       kauth: new KeycloakContext({ req })
     }

--- a/examples/subscriptions.js
+++ b/examples/subscriptions.js
@@ -1,0 +1,98 @@
+const express = require('express')
+const { PubSub } = require('graphql-subscriptions')
+const { execute, subscribe } = require('graphql')
+const { SubscriptionServer } = require('subscriptions-transport-ws')
+
+const { ApolloServer, gql } = require('apollo-server-express')
+
+const { configureKeycloak } = require('./common')
+
+const { 
+  KeycloakContext,
+  KeycloakSubscriptionContext,
+  KeycloakTypeDefs,
+  KeycloakSchemaDirectives,
+  KeycloakSubscriptionHandler
+} = require('../')
+
+
+const app = express()
+
+const graphqlPath = '/graphql'
+
+// perform the standard keycloak-connect middleware setup on our app
+// return the initialized keycloak object
+const { keycloak } = configureKeycloak(app, graphqlPath)
+
+const pubsub = new PubSub()
+
+// set up the pubsub to publish a message every 2 seconds
+const TOPIC = 'HELLO'
+setInterval(() => {
+  pubsub.publish(TOPIC, { testSubscription: `tesing... ${Date.now()}`})
+}, 2000)
+
+const typeDefs = gql`
+  type Query {
+    hello: String!
+  }
+
+  type Subscription {
+    testSubscription: String!
+  }
+`
+
+const resolvers = {
+  Query: {
+    hello: (obj, args, context, info) => {
+      return `Hello world`
+    }
+  },
+  Subscription: {
+    testSubscription: {
+      subscribe: () => pubsub.asyncIterator(TOPIC)
+    }
+  }
+}
+
+// Initialize the voyager server with our schema and context
+
+const server = new ApolloServer({
+  typeDefs: [KeycloakTypeDefs, typeDefs],
+  schemaDirectives: KeycloakSchemaDirectives,
+  resolvers,
+  context: ({ req, connection }) => {
+    console.log(connection)
+    return {
+      kauth: new KeycloakContext({ req })
+    }
+  }
+})
+
+server.applyMiddleware({ app })
+
+const port = 4000
+
+const httpServer = app.listen({ port }, () => {
+  console.log(`🚀 Server ready at http://localhost:${port}${server.graphqlPath}`)
+
+  // Initialize the keycloak subscription handler passing in our keycloak instance
+  // protect: false means that subscriptions will not fail
+  // if the token is not provided by the client in connectionParams
+  const keycloakSubscriptionHandler = new KeycloakSubscriptionHandler({ keycloak })
+  new SubscriptionServer({
+    execute,
+    subscribe,
+    schema: server.schema,
+    onConnect: async (connectionParams, websocket, connectionContext) => {
+      const token = await keycloakSubscriptionHandler.onSubscriptionConnect(connectionParams)
+      return {
+        kauth: new KeycloakSubscriptionContext(token)
+      }
+    }
+  }, {
+    server: httpServer,
+    path: graphqlPath
+  })
+})
+

--- a/examples/subscriptions_advanced.js
+++ b/examples/subscriptions_advanced.js
@@ -64,14 +64,11 @@ const resolvers = {
   }
 }
 
-// Initialize the voyager server with our schema and context
-
 const server = new ApolloServer({
   typeDefs: [KeycloakTypeDefs, typeDefs],
   schemaDirectives: KeycloakSchemaDirectives,
   resolvers,
-  context: ({ req, connection }) => {
-    console.log(connection)
+  context: ({ req }) => {
     return {
       kauth: new KeycloakContext({ req })
     }

--- a/examples/subscriptions_advanced.js
+++ b/examples/subscriptions_advanced.js
@@ -1,0 +1,107 @@
+const express = require('express')
+const { PubSub } = require('graphql-subscriptions')
+const { execute, subscribe } = require('graphql')
+const { SubscriptionServer } = require('subscriptions-transport-ws')
+
+const { ApolloServer, gql } = require('apollo-server-express')
+
+const { configureKeycloak } = require('./common')
+
+const { 
+  KeycloakContext,
+  KeycloakSubscriptionContext,
+  KeycloakTypeDefs,
+  KeycloakSchemaDirectives,
+  KeycloakSubscriptionHandler,
+  auth
+} = require('../')
+
+
+const app = express()
+
+const graphqlPath = '/graphql'
+
+// perform the standard keycloak-connect middleware setup on our app
+// return the initialized keycloak object
+const { keycloak } = configureKeycloak(app, graphqlPath)
+
+const pubsub = new PubSub()
+
+// set up the pubsub to publish a message every 2 seconds
+const TOPIC = 'HELLO'
+setInterval(() => {
+  pubsub.publish(TOPIC, { 
+    testSubscription: `tesing... ${Date.now()}`,
+    testSubscriptionProtected: `tesing... ${Date.now()}`
+  })
+}, 2000)
+
+
+const typeDefs = gql`
+  type Query {
+    hello: String!
+  }
+
+  type Subscription {
+    testSubscription: String!
+    testSubscriptionProtected: String!
+  }
+`
+
+const resolvers = {
+  Query: {
+    hello: (obj, args, context, info) => {
+      return `Hello world`
+    }
+  },
+  Subscription: {
+    testSubscription: {
+      subscribe: () => pubsub.asyncIterator(TOPIC)
+    },
+    testSubscriptionProtected: {
+      subscribe: auth(() => pubsub.asyncIterator(TOPIC))
+    }
+  }
+}
+
+// Initialize the voyager server with our schema and context
+
+const server = new ApolloServer({
+  typeDefs: [KeycloakTypeDefs, typeDefs],
+  schemaDirectives: KeycloakSchemaDirectives,
+  resolvers,
+  context: ({ req, connection }) => {
+    console.log(connection)
+    return {
+      kauth: new KeycloakContext({ req })
+    }
+  }
+})
+
+server.applyMiddleware({ app })
+
+const port = 4000
+
+const httpServer = app.listen({ port }, () => {
+  console.log(`🚀 Server ready at http://localhost:${port}${server.graphqlPath}`)
+
+  // Initialize the keycloak subscription handler passing in our keycloak instance
+  // protect: false means that subscriptions will not fail
+  // if the token is not provided by the client in connectionParams
+  const keycloakSubscriptionHandler = new KeycloakSubscriptionHandler({ keycloak, protect: false })
+  new SubscriptionServer({
+    execute,
+    subscribe,
+    schema: server.schema,
+    onConnect: async (connectionParams, websocket, connectionContext) => {
+      const token = await keycloakSubscriptionHandler.onSubscriptionConnect(connectionParams)
+      return {
+        kauth: new KeycloakSubscriptionContext(token)
+      }
+    }
+  }, {
+    server: httpServer,
+    path: graphqlPath
+  })
+})
+

--- a/package.json
+++ b/package.json
@@ -42,9 +42,11 @@
     "coveralls": "3.0.4",
     "express": "4.17.1",
     "graphql": "14.4.1",
+    "graphql-subscriptions": "^1.1.0",
     "keycloak-request-token": "^0.1.0",
     "nyc": "14.1.1",
     "sinon": "^7.3.2",
+    "subscriptions-transport-ws": "^0.9.16",
     "ts-node": "8.3.0",
     "tslint": "5.18.0",
     "typescript": "3.5.2"

--- a/scripts/getToken.js
+++ b/scripts/getToken.js
@@ -12,7 +12,7 @@ const settings = {
 tokenRequester(baseUrl, settings)
   .then((token) => {
     const headers = {
-      Authorization: `Bearer ${token}`
+      Authorization: `Bearer ${token}`, clientId: settings.client_id
     }
     console.log(JSON.stringify(headers))
   }).catch((err) => {

--- a/src/KeycloakContext.ts
+++ b/src/KeycloakContext.ts
@@ -15,6 +15,7 @@ export class KeycloakContext implements AuthContextProvider {
   }
 
   public hasRole (role: string): boolean {
-    return ((this.accessToken && !this.accessToken.isExpired()) && this.accessToken.hasRole(role)) ? true : false
+    //@ts-ignore
+    return this.isAuthenticated() && this.accessToken.hasRole(role)
   }
 }

--- a/src/KeycloakContext.ts
+++ b/src/KeycloakContext.ts
@@ -1,6 +1,28 @@
 import { AuthContextProvider } from './api'
 import Keycloak from 'keycloak-connect'
 
+/**
+ * Context builder class that adds the Keycloak token from `req.kauth` into the GraphQL context.
+ * This class *must* be added to the context under `context.kauth`.
+ * 
+ * 
+ * Example usage in Apollo Server:
+ * 
+ * ```javascript
+ * const server = new ApolloServer({
+ *   typeDefs,
+ *   resolvers,
+ *   context: ({ req }) => {
+ *     return {
+ *       kauth: new KeycloakContext({ req })
+ *       // your other things you want in your context
+ *     }
+ *   }
+ * })
+ * ```
+ * Note: This class gets the token details from `req.kauth` so you must ensure that the keycloak middleware
+ * is installed on the graphql endpoint
+ */
 export class KeycloakContext implements AuthContextProvider {
   public readonly request: Keycloak.GrantedRequest
   public readonly accessToken: Keycloak.Token | undefined

--- a/src/KeycloakContext.ts
+++ b/src/KeycloakContext.ts
@@ -1,6 +1,44 @@
 import { AuthContextProvider } from './api'
 import Keycloak from 'keycloak-connect'
 
+export class KeycloakContextBase implements AuthContextProvider {
+  public readonly accessToken: Keycloak.Token | undefined
+
+  constructor (token?: Keycloak.Token) {
+    this.accessToken = token
+  }
+
+  /**
+   * returns true if a valid, non expired access token is present
+   */
+  public isAuthenticated (): boolean {
+    return (this.accessToken && !this.accessToken.isExpired()) ? true : false 
+  }
+
+  /**
+   * 
+   * Checks that the authenticated keycloak user has the role.
+   * If the user has the role, the next resolver is called.
+   * If the user does not have the role, an error is thrown.
+   * 
+   * If an array of roles is passed, it checks that the user has at least one of the roles
+   * 
+   * By default, hasRole checks for keycloak client roles.
+   * Example: `hasRole('admin')` will check the logged in user has the client role named admin.
+   * 
+   * It also is possible to check for realm roles and application roles.
+   * * `hasRole('realm:admin')` will check the logged in user has the admin realm role
+   * * `hasRole('some-other-app:admin')` will check the loged in user has the admin realm role in a different application
+   * 
+   * 
+   * @param role the role or array of roles to check
+   */
+  public hasRole (role: string): boolean {
+    //@ts-ignore
+    return this.isAuthenticated() && this.accessToken.hasRole(role)
+  }
+}
+
 /**
  * Context builder class that adds the Keycloak token from `req.kauth` into the GraphQL context.
  * This class *must* be added to the context under `context.kauth`.
@@ -22,22 +60,49 @@ import Keycloak from 'keycloak-connect'
  * ```
  * Note: This class gets the token details from `req.kauth` so you must ensure that the keycloak middleware
  * is installed on the graphql endpoint
+ * 
  */
-export class KeycloakContext implements AuthContextProvider {
+export class KeycloakContext extends KeycloakContextBase implements AuthContextProvider {
   public readonly request: Keycloak.GrantedRequest
   public readonly accessToken: Keycloak.Token | undefined
 
   constructor ({ req }: { req: Keycloak.GrantedRequest }) {
+    const token = (req && req.kauth && req.kauth.grant) ? req.kauth.grant.access_token : undefined
+    super(token)
     this.request = req
-    this.accessToken = (req && req.kauth && req.kauth.grant) ? req.kauth.grant.access_token : undefined
   }
+}
 
-  public isAuthenticated (): boolean {
-    return (this.accessToken && !this.accessToken.isExpired()) ? true : false 
-  }
-
-  public hasRole (role: string): boolean {
-    //@ts-ignore
-    return this.isAuthenticated() && this.accessToken.hasRole(role)
+/**
+ * Context builder class that extends the original KeycloakContext object
+ * but is used for building the context for subscriptions
+ * 
+ * example usage: 
+ * 
+ * ```javascript
+ * const keycloakSubscriptionHandler = new KeycloakSubscriptionHandler({ keycloak })
+ *   new SubscriptionServer({
+ *     execute,
+ *     subscribe,
+ *     schema: server.schema,
+ *     onConnect: async (connectionParams, websocket, connectionContext) => {
+ *       const token = await keycloakSubscriptionHandler.onSubscriptionConnect(connectionParams)
+ *       return {
+ *         kauth: new KeycloakSubscriptionContext(token)
+ *       }
+ *     }
+ *   }, {
+ *     server,
+ *     path: '/graphql'
+ *   })
+ * ```
+ */
+export class KeycloakSubscriptionContext extends KeycloakContextBase {
+  /**
+   * 
+   * @param token a keycloak token object
+   */
+  constructor(token: Keycloak.Token) {
+    super(token)
   }
 }

--- a/src/KeycloakContext.ts
+++ b/src/KeycloakContext.ts
@@ -1,21 +1,20 @@
 import { AuthContextProvider } from './api'
+import Keycloak from 'keycloak-connect'
 
 export class KeycloakContext implements AuthContextProvider {
-  public readonly request: any
-  public readonly accessToken: any
-  public readonly authenticated: boolean
+  public readonly request: Keycloak.GrantedRequest
+  public readonly accessToken: Keycloak.Token | undefined
 
-  constructor ({ req }: { req: any }) {
+  constructor ({ req }: { req: Keycloak.GrantedRequest }) {
     this.request = req
     this.accessToken = (req && req.kauth && req.kauth.grant) ? req.kauth.grant.access_token : undefined
-    this.authenticated = this.accessToken && !this.accessToken.isExpired()
   }
 
   public isAuthenticated (): boolean {
-    return this.authenticated
+    return (this.accessToken && !this.accessToken.isExpired()) ? true : false 
   }
 
   public hasRole (role: string): boolean {
-    return this.isAuthenticated() && this.accessToken.hasRole(role)
+    return ((this.accessToken && !this.accessToken.isExpired()) && this.accessToken.hasRole(role)) ? true : false
   }
 }

--- a/src/KeycloakSubscriptionHandler.ts
+++ b/src/KeycloakSubscriptionHandler.ts
@@ -1,12 +1,10 @@
+import Keycloak from './KeycloakTypings'
 import { Token } from './KeycloakToken'
 import { KeycloakSubscriptionHandlerOptions } from './api'
 
 export class KeycloakSubscriptionHandler {
 
-  public readonly keycloakConfig: any
-  public readonly schemaDirectives: any
-  public readonly authContextProvider: any
-  public keycloak: any
+  public keycloak: Keycloak.Keycloak
 
   constructor (options: KeycloakSubscriptionHandlerOptions) {
     if (!options.keycloak) {

--- a/src/KeycloakSubscriptionHandler.ts
+++ b/src/KeycloakSubscriptionHandler.ts
@@ -2,20 +2,65 @@ import Keycloak from './KeycloakTypings'
 import { Token } from './KeycloakToken'
 import { KeycloakSubscriptionHandlerOptions } from './api'
 
+/**
+ * Provides the onSubscriptionConnect function that is used to validate incoming
+ * websocket connections for subscriptions.
+ * 
+ * Parses and validates the keycloak token sent by the client in the connectionParams
+ * 
+ * Example usage:
+ * 
+ * ```javascript
+ * const server = app.listen({ port }, () => {
+ *   console.log(`🚀 Server ready at http://localhost:${port}${server.graphqlPath}`)
+ *
+ *   const keycloakSubscriptionHandler = new KeycloakSubscriptionHandler({ keycloak })
+ *   new SubscriptionServer({
+ *     execute,
+ *     subscribe,
+ *     schema: server.schema,
+ *     onConnect: async (connectionParams, websocket, connectionContext) => {
+ *       const token = await keycloakSubscriptionHandler.onSubscriptionConnect(connectionParams)
+ *       return {
+ *         kauth: new KeycloakSubscriptionContext(token)
+ *       }
+ *     }
+ *   }, {
+ *     server,
+ *     path: '/graphql'
+ *   })
+ *})
+ *```
+ */
 export class KeycloakSubscriptionHandler {
 
   public keycloak: Keycloak.Keycloak
+  public protect?: boolean
 
+  /**
+   * 
+   * @param options 
+   */
   constructor (options: KeycloakSubscriptionHandlerOptions) {
     if (!options.keycloak) {
       throw new Error('missing keycloak instance in options')
     }
     this.keycloak = options.keycloak
+    this.protect = (options.protect !== null && options.protect !== undefined) ? options.protect : true
   }
 
-  public async onSubscriptionConnect(connectionParams: any, webSocket: any, context: any): Promise<any> {
+  /**
+   * 
+   * @param connectionParams 
+   * @param webSocket 
+   * @param context 
+   */
+  public async onSubscriptionConnect(connectionParams: any, webSocket: any, context: any): Promise<Keycloak.Token | undefined | Error> {
     if (!connectionParams || typeof connectionParams !== 'object') {
-      throw new Error('Access Denied - missing connection parameters for Authentication')
+      if (this.protect === true) {
+        throw new Error('Access Denied - missing connection parameters for Authentication')
+      }
+      return
     }
     const header = connectionParams.Authorization
                   || connectionParams.authorization
@@ -23,11 +68,15 @@ export class KeycloakSubscriptionHandler {
                   || connectionParams.auth
     const clientId = connectionParams.clientId
     if (!header) {
-      throw new Error('Access Denied - missing Authorization field in connection parameters')
+      if (this.protect === true) {
+        throw new Error('Access Denied - missing Authorization field in connection parameters')
+      }
+      return
     }
     const token = this.getBearerTokenFromHeader(header, clientId)
     try {
       await this.keycloak.grantManager.validateToken(token, 'Bearer')
+      //@ts-ignore
       return token
     } catch (e) {
       throw new Error(`Access Denied - ${e}`)

--- a/src/KeycloakTypings.d.ts
+++ b/src/KeycloakTypings.d.ts
@@ -1,0 +1,345 @@
+import * as express from 'express'
+
+/**
+ * The JavaScript module is exported as a single function, but for TypeScript we
+ * need to export the function and a set of interfaces so developers can assign
+ * types such as Grant, Token, etc. to variables in their own code.
+ * 
+ * To achieve this we export "KeycloakConnect" that references a namespace
+ * containing our typings, and a static instance exposing the constructor
+ */
+declare const KeycloakConnect: KeycloakConnectStatic
+export = KeycloakConnect
+
+interface KeycloakConnectStatic {
+  new (options: KeycloakConnect.KeycloakOptions, config: KeycloakConnect.KeycloakConfig): KeycloakConnect.Keycloak
+}
+
+declare namespace KeycloakConnect {
+
+  interface KeycloakConfig {
+    'confidential-port': string|number
+    'auth-server-url': string
+    'resource': string
+    'ssl-required': string
+    'bearer-only'?: boolean
+    realm: string
+  }
+
+  interface KeycloakOptions {
+    scope?: string
+    store?: any
+    cookies?: boolean
+  }
+
+  interface GrantProperties {
+    access_token?: string
+    refresh_token?: string
+    id_token?: string
+    expires_in?: string
+    token_type?: string
+  }
+
+  interface Token {
+    isExpired(): boolean
+    hasRole(roleName: string): boolean
+    hasApplicationRole(appName: string, roleName: string): boolean
+    hasRealmRole(roleName: string): boolean
+  }
+
+  interface GrantManager {
+    /**
+     * Use the direct grant API to obtain a grant from Keycloak.
+     *
+     * The direct grant API must be enabled for the configured realm
+     * for this method to work. This function ostensibly provides a
+     * non-interactive, programatic way to login to a Keycloak realm.
+     *
+     * @param {String} username The username.
+     * @param {String} password The cleartext password.
+     */
+    obtainDirectly(username: string, password: string): Promise<Grant>
+
+    /**
+     * Obtain a grant from a previous interactive login which results in a code.
+     *
+     * This is typically used by servers which receive the code through a
+     * redirect_uri when sending a user to Keycloak for an interactive login.
+     *
+     * An optional session ID and host may be provided if there is desire for
+     * Keycloak to be aware of this information.  They may be used by Keycloak
+     * when session invalidation is triggered from the Keycloak console itself
+     * during its postbacks to `/k_logout` on the server.
+     *
+     * @param {String} code The code from a successful login redirected from Keycloak.
+     * @param {String} sessionId Optional opaque session-id.
+     * @param {String} sessionHost Optional session host for targetted Keycloak console post-backs.
+     */
+    obtainFromCode(code: string, sessionid?: string, sessionHost?: string, callback?: (err: Error, grant: Grant) => void): Promise<Grant>
+
+
+    /**
+     * Obtain a service account grant.
+     * Client option 'Service Accounts Enabled' needs to be on.
+     *
+     * This method returns or promise or may optionally take a callback function.
+     *
+     * @param {Function} callback Optional callback, if not using promises.
+     */
+    obtainFromClientCredentials (callback?: (err: Error, grant: Grant) => void, scopeParam?: string): Promise<Grant>
+
+    /**
+     * Ensure that a grant is *fresh*, refreshing if required & possible.
+     *
+     * If the access_token is not expired, the grant is left untouched.
+     *
+     * If the access_token is expired, and a refresh_token is available,
+     * the grant is refreshed, in place (no new object is created),
+     * and returned.
+     *
+     * If the access_token is expired and no refresh_token is available,
+     * an error is provided.
+     *
+     * @param {Grant} grant The grant object to ensure freshness of
+     */
+    ensureFreshness (grant: Grant): Promise<Grant>
+
+    /**
+     * Perform live validation of an `access_token` against the Keycloak server.
+     *
+     * @param {Token|String} token The token to validate.
+     * @param {Function} callback Callback function if not using promises.
+     *
+     * @return {boolean} `false` if the token is invalid, or the same token if valid.
+     */
+    validateAccessToken<T extends Token|string>(token: T): Promise<false|T>
+
+    /**
+     * Create a `Grant` object from a string of JSON data.
+     *
+     * This method creates the `Grant` object, including
+     * the `access_token`, `refresh_token` and `id_token`
+     * if available, and validates each for expiration and
+     * against the known public-key of the server.
+     *
+     * @param {String|GrantProperties} rawData The raw JSON string received from the Keycloak server or from a client.
+     * @return {Promise} A promise reoslving a grant.
+     */
+    createGrant(data: string|GrantProperties): Promise<Grant>
+
+    /**
+     * Validate the grant and all tokens contained therein.
+     *
+     * This method examines a grant (in place) and rejects
+     * if any of the tokens are invalid. After this method
+     * resolves, the passed grant is guaranteed to have
+     * valid tokens.
+     *
+     * @param {Grant} grant The grant to validate.
+     *
+     * @return {Promise} That resolves to a validated grant or
+     * rejects with an error if any of the tokens are invalid.
+     */
+    validateGrant(grant: Grant): Promise<Grant>
+
+    /**
+     * Validate a token.
+     *
+     * This method accepts a token, and returns a promise
+     *
+     * If the token is valid the promise will be resolved with the token
+     * 
+     * If the token is undefined or fails validation an applicable error is returned
+     * 
+     * @return {Promise} That resolve a token
+     */
+    validateToken(token?: Token, expectedType?: string): Promise<Token>
+  }
+
+  interface Grant extends GrantProperties {
+    /**
+     * Update this grant in-place given data in another grant.
+     *
+     * This is used to avoid making client perform extra-bookkeeping
+     * to maintain the up-to-date/refreshed grant-set.
+     */
+    update(grant: Grant): void
+
+    /**
+     * Returns the raw String of the grant, if available.
+     *
+     * If the raw string is unavailable (due to programatic construction)
+     * then `undefined` is returned.
+     */
+    toString(): string|undefined
+
+    /**
+     * Determine if this grant is expired/out-of-date.
+     *
+     * Determination is made based upon the expiration status of the `access_token`.
+     *
+     * An expired grant *may* be possible to refresh, if a valid
+     * `refresh_token` is available.
+     *
+     * @return {boolean} `true` if expired, otherwise `false`.
+     */
+    isExpired(): boolean
+  }
+
+  type GaurdFn = (accessToken: string, req: express.Request, res: express.Response) => boolean
+
+
+  interface Keycloak {
+    grantManager: GrantManager
+
+    /**
+     * Obtain an array of middleware for use in your application.
+     *
+     * Generally this should be installed at the root of your application,
+     * as it provides general wiring for Keycloak interaction, without actually
+     * causing Keycloak to get involved with any particular URL until asked
+     * by using `protect(...)`.
+     *
+     * Example:
+     *
+     *     var app = express();
+     *     var keycloak = new Keycloak();
+     *     app.use( keycloak.middleware() );
+     *
+     * Options:
+     *
+     *  - `logout` URL for logging a user out. Defaults to `/logout`.
+     *  - `admin` Root URL for Keycloak admin callbacks.  Defaults to `/`.
+     *
+     * @param {Object} options Optional options for specifying details.
+     */
+    middleware(options?: { admin?: string, logout?: string }): express.RequestHandler[]
+
+    /**
+     * Apply protection middleware to an application or specific URL.
+     *
+     * If no `spec` parameter is provided, the subsequent handlers will
+     * be invoked if the user is authenticated, regardless of what roles
+     * he or she may or may not have.
+     *
+     * If a user is not currently authenticated, the middleware will cause
+     * the authentication workflow to begin by redirecting the user to the
+     * Keycloak installation to login.  Upon successful login, the user will
+     * be redirected back to the originally-requested URL, fully-authenticated.
+     *
+     * If a `spec` is provided, the same flow as above will occur to ensure that
+     * a user it authenticated.  Once authenticated, the spec will then be evaluated
+     * to determine if the user may or may not access the following resource.
+     *
+     * The `spec` may be either a `String`, specifying a single required role,
+     * or a function to make more fine-grained determination about access-control
+     *
+     * If the `spec` is a `String`, then the string will be interpreted as a
+     * role-specification according to the following rules:
+     *
+     *  - If the string starts with `realm:`, the suffix is treated as the name
+     *    of a realm-level role that is required for the user to have access.
+     *  - If the string contains a colon, the portion before the colon is treated
+     *    as the name of an application within the realm, and the portion after the
+     *    colon is treated as a role within that application.  The user then must have
+     *    the named role within the named application to proceed.
+     *  - If the string contains no colon, the entire string is interpreted as
+     *    as the name of a role within the current application (defined through
+     *    the installed `keycloak.json` as provisioned within Keycloak) that the
+     *    user must have in order to proceed.
+     *
+     * Example
+     *
+     *     // Users must have the `special-people` role within this application
+     *     app.get( '/special/:page', keycloak.protect( 'special-people' ), mySpecialHandler );
+     *
+     * If the `spec` is a function, it may take up to two parameters in order to
+     * assist it in making an authorization decision: the access token, and the
+     * current HTTP request.  It should return `true` if access is allowed, otherwise
+     * `false`.
+     *
+     * The `token` object has a method `hasRole(...)` which follows the same rules
+     * as above for `String`-based specs.
+     *
+     *     // Ensure that users have either `nicepants` realm-level role, or `mr-fancypants` app-level role.
+     *     function pants(token, request) {
+     *       return token.hasRole( 'realm:nicepants') || token.hasRole( 'mr-fancypants');
+     *     }
+     *
+     *     app.get( '/fancy/:page', keycloak.protect( pants ), myPantsHandler );
+     *
+     * With no spec, simple authentication is all that is required:
+     *
+     *     app.get( '/complain', keycloak.protect(), complaintHandler );
+     *
+     * @param {String} spec The protection spec (optional)
+     */
+    protect(spec: GaurdFn|string): express.RequestHandler
+
+    /**
+     * Callback made upon successful authentication of a user.
+     *
+     * By default, this a no-op, but may assigned to another
+     * function for application-specific login which may be useful
+     * for linking authentication information from Keycloak to
+     * application-maintained user information.
+     *
+     * The `request.kauth.grant` object contains the relevant tokens
+     * which may be inspected.
+     *
+     * For instance, to obtain the unique subject ID:
+     *
+     *     request.kauth.grant.id_token.sub => bf2056df-3803-4e49-b3ba-ff2b07d86995
+     *
+     * @param {Object} request The HTTP request.
+     */
+    authenticated(req: express.Request): void
+
+    /**
+     * Callback made upon successful de-authentication of a user.
+     *
+     * By default, this is a no-op, but may be used by the application
+     * in the case it needs to remove information from the user's session
+     * or otherwise perform additional logic once a user is logged out.
+     *
+     * @param {Object} request The HTTP request.
+     */
+    deauthenticated(req: express.Request): void
+
+    /**
+     * Replaceable function to handle access-denied responses.
+     *
+     * In the event the Keycloak middleware decides a user may
+     * not access a resource, or has failed to authenticate at all,
+     * this function will be called.
+     *
+     * By default, a simple string of "Access denied" along with
+     * an HTTP status code for 403 is returned.  Chances are an
+     * application would prefer to render a fancy template.
+     * @param {Object} request The HTTP request.
+     * @param {Object} response The HTTP response.
+     */
+    accessDenied(req: express.Request, res: express.Response): void
+
+
+    getGrant(req: express.Request, res: express.Response): Promise<Grant>
+
+    storeGrant(grant: Grant, req: express.Request, res: express.Response): Grant
+
+    unstoreGrant(sessionId: string): void
+
+    getGrantFromCode(code: string, req: express.Request, res: express.Response): Promise<Grant>
+
+    loginUrl(uuid: string, redirectUrl: string): string
+
+    logoutUrl(redirectUrl: string): string
+
+    accountUrl(): string
+
+    // Uses deprecated method
+    // getAccount
+
+    redirectToLogin(req: express.Request): boolean
+  }
+
+}

--- a/src/api/KeycloakSubscriptionHandlerOptions.ts
+++ b/src/api/KeycloakSubscriptionHandlerOptions.ts
@@ -1,5 +1,21 @@
 import Keycloak from '../KeycloakTypings'
 
 export interface KeycloakSubscriptionHandlerOptions {
-  keycloak: Keycloak.Keycloak
+  
+  /**
+   * The initialized keycloak object from keycloak-connect
+   */
+  keycloak: Keycloak.Keycloak,
+
+  /**
+   * If true, then all subscriptions must be authenticated. 
+   * Clients that do not supply the correct connectionParams will be blocked
+   * 
+   * If false, then the connectionParams will still be parsed and validated
+   * but unauthenticated clients (i.e. no connectionParams) will not be immediately blocked.
+   * This means it can be decided on an individual subscription level.
+   * Allowing for publicly and non publicly accessible subscriptions
+   * 
+   */
+  protect?: boolean
 }

--- a/src/api/KeycloakSubscriptionHandlerOptions.ts
+++ b/src/api/KeycloakSubscriptionHandlerOptions.ts
@@ -1,3 +1,5 @@
+import Keycloak from '../KeycloakTypings'
+
 export interface KeycloakSubscriptionHandlerOptions {
-  keycloak: any
+  keycloak: Keycloak.Keycloak
 }

--- a/src/api/SchemaDirectives.ts
+++ b/src/api/SchemaDirectives.ts
@@ -1,3 +1,0 @@
-import { SchemaDirectiveVisitor } from 'graphql-tools'
-
-export type SchemaDirectives = Record<string, typeof SchemaDirectiveVisitor>

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,3 @@
 export * from './AuthContextProvider'
 export * from './KeycloakSubscriptionHandlerOptions'
-export * from './SchemaDirectives'
 export * from './typeDefs'

--- a/src/directives/directiveResolvers.ts
+++ b/src/directives/directiveResolvers.ts
@@ -1,3 +1,41 @@
+/**
+ * 
+ * @param next - The resolver function you want to wrap with the auth resolver
+ * 
+ * Checks if the incoming request to the GraphQL server is authenticated.
+ * Does this by checking that `context.kauth` is present and that the token is valid.
+ * The keycloak middleware must be set up on your GraphQL endpoint.
+ * 
+ * Example usage:
+ * 
+ * ```javascript
+ * const { auth } = require('keycloak-connect-graphql')
+ * 
+ * const typeDefs = gql`
+ *   type Query {
+ *     hello: String
+ *   }
+ * `
+ * 
+ * const hello = (root, args, context, info) => 'Hello World'
+ * 
+ * const resolvers = {
+ *   hello: auth(hello)
+ * }
+ * 
+ * const server = new ApolloServer({
+  *   typeDefs,
+  *   resolvers,
+  *   schemaDirectives: [KeycloakSchemaDirectives],
+  *   context: ({ req }) => {
+   *     return {
+   *       kauth: new KeycloakContext({ req })
+   *     }
+   *   }
+  * })
+ * ```
+ * 
+ */
 export const auth = (next: Function) => (root: any, args: any, context: any, info: any) => {
   if (!context.kauth || !context.kauth.isAuthenticated()) {
     throw new Error(`User not Authenticated`)
@@ -5,6 +43,53 @@ export const auth = (next: Function) => (root: any, args: any, context: any, inf
   return next(root, args, context, info)
 }
 
+/**
+ * 
+ * @param roles - The role or array of roles you want to authorize the user against.
+ * 
+ * Checks that the authenticated keycloak user has the role.
+ * If the user has the role, the next resolver is called.
+ * If the user does not have the role, an error is thrown.
+ * 
+ * If an array of roles is passed, it checks that the user has at least one of the roles
+ * 
+ * By default, hasRole checks for keycloak client roles.
+ * Example: `hasRole('admin')` will check the logged in user has the client role named admin.
+ * 
+ * It also is possible to check for realm roles and application roles.
+ * * `hasRole('realm:admin')` will check the logged in user has the admin realm role
+ * * `hasRole('some-other-app:admin')` will check the loged in user has the admin realm role in a different application
+ * 
+ * 
+ * Example usage:
+ * 
+ * ```javascript
+ * const { hasRole } = require('keycloak-connect-graphql')
+ * 
+ * const typeDefs = gql`
+ *   type Query {
+ *     hello: String
+ *   }
+ * `
+ * 
+ * const hello = (root, args, context, info) => 'Hello World'
+ * 
+ * const resolvers = {
+ *   hello: hasRole('admin')(hello)
+ * } 
+ * 
+ * const server = new ApolloServer({
+ *   typeDefs,
+ *   resolvers,
+ *   schemaDirectives: [KeycloakSchemaDirectives],
+ *   context: ({ req }) => {
+  *     return {
+  *       kauth: new KeycloakContext({ req })
+  *     }
+  *   }
+ * })
+ * ```
+ */
 export const hasRole = (roles: Array<string>) => (next: Function) => (root: any, args: any, context: any, info: any) => {
   if (!context.kauth || !context.kauth.isAuthenticated()) {
     throw new Error(`User not Authenticated`)

--- a/src/directives/index.ts
+++ b/src/directives/index.ts
@@ -1,8 +1,40 @@
-export * from './directiveResolvers'
-
+import { SchemaDirectiveVisitor } from 'graphql-tools'
 import { HasRoleDirective, AuthDirective } from './schemaDirectiveVisitors'
 
-export const KeycloakSchemaDirectives = {
+export type SchemaDirectiveMap = Record<string, typeof SchemaDirectiveVisitor>
+
+/**
+ * Object that contains directive implementations for Apollo Server. Pass this into Apollo Server
+ * to enable schemaDirectives such as `@auth` and `@hasRole`
+ * 
+ * Example usage:
+ * 
+ * ```javascript
+ * const typeDefs = gql`
+ *   type Query {
+ *     hello: String! @auth
+ *   }
+ *
+ *   type mutation {
+ *     changeSomething(arg: String!): String! @hasRole(role: "admin")
+ *   }
+ * `
+ * const server = new ApolloServer({
+ *   typeDefs,
+ *   resolvers,
+ *   schemaDirectives: [KeycloakSchemaDirectives],
+ *   context: ({ req }) => {
+  *     return {
+  *       kauth: new KeycloakContext({ req })
+  *     }
+  *   }
+ * })
+ * ```
+ */
+export const KeycloakSchemaDirectives: SchemaDirectiveMap = {
   auth: AuthDirective,
   hasRole: HasRoleDirective
 }
+
+
+export * from './directiveResolvers'

--- a/test/AuthContextProvider.test.ts
+++ b/test/AuthContextProvider.test.ts
@@ -1,4 +1,5 @@
 import test from 'ava'
+import Keycloak from 'keycloak-connect'
 
 import { KeycloakContext } from '../src/KeycloakContext'
 
@@ -17,10 +18,11 @@ test('AuthContextProvider accessToken is the access_token in req.kauth', (t) => 
         }
       }
     }
-  }
+  } as Keycloak.GrantedRequest
 
   const provider = new KeycloakContext({ req })
-  t.deepEqual(provider.accessToken, req.kauth.grant.access_token)
+  const token = req.kauth.grant && req.kauth.grant.access_token ? req.kauth.grant.access_token : undefined
+  t.deepEqual(provider.accessToken, token)
 })
 
 test('AuthContextProvider hasRole calls hasRole in the access_token', (t) => {
@@ -39,7 +41,7 @@ test('AuthContextProvider hasRole calls hasRole in the access_token', (t) => {
         }
       }
     }
-  }
+  } as Keycloak.GrantedRequest
 
   const provider = new KeycloakContext({ req })
   t.truthy(provider.hasRole(''))
@@ -59,7 +61,7 @@ test('AuthContextProvider.isAuthenticated is true when token is defined and isEx
         }
       }
     }
-  }
+  } as Keycloak.GrantedRequest
 
   const provider = new KeycloakContext({ req })
   t.truthy(provider.isAuthenticated())
@@ -79,7 +81,7 @@ test('AuthContextProvider.isAuthenticated is false when token is defined but isE
         }
       }
     }
-  }
+  } as Keycloak.GrantedRequest
 
   const provider = new KeycloakContext({ req })
   t.false(provider.isAuthenticated())
@@ -99,7 +101,7 @@ test('AuthContextProvider.hasRole is false if token is expired', (t) => {
         }
       }
     }
-  }
+  } as Keycloak.GrantedRequest
 
   const provider = new KeycloakContext({ req })
   t.false(provider.hasRole(''))

--- a/test/KeycloakSecurityService.test.ts
+++ b/test/KeycloakSecurityService.test.ts
@@ -1,4 +1,5 @@
 import test from 'ava'
+import Keycloak from '../src/KeycloakTypings'
 
 import { KeycloakSubscriptionHandler } from '../src/KeycloakSubscriptionHandler'
 import { Token } from '../src/KeycloakToken';
@@ -12,7 +13,7 @@ test('onSubscriptionConnect throws if no connectionParams Provided', async t => 
         })
       }
     }
-  }
+  } as unknown as Keycloak.Keycloak
 
   const securityService = new KeycloakSubscriptionHandler({ keycloak: stubKeycloak })
 
@@ -30,7 +31,7 @@ test('onSubscriptionConnect throws if no connectionParams is not an object', asy
         })
       }
     }
-  }
+  } as unknown as Keycloak.Keycloak
 
   const securityService = new KeycloakSubscriptionHandler({ keycloak: stubKeycloak })
   const connectionParams = 'not an object'
@@ -49,7 +50,7 @@ test('onSubscriptionConnect throws if no Auth provided', async t => {
         })
       }
     }
-  }
+  } as unknown as Keycloak.Keycloak
 
   const securityService = new KeycloakSubscriptionHandler({ keycloak: stubKeycloak })
   const connectionParams = { Authorization: undefined }
@@ -68,7 +69,7 @@ test('onSubscriptionConnect returns a token Object if the keycloak library consi
         })
       }
     }
-  }
+  } as unknown as Keycloak.Keycloak
 
   const tokenString = 'Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJfa29BTUtBcW1xQjcxazNGeDdBQ0xvNXZqMXNoWVZwSkdJM2FScFl4allZIn0.eyJqdGkiOiJjN2UyMzA0NS00NGVmLTQ1ZDItOGY0Yy1jODA4OTlhYzljYzIiLCJleHAiOjE1NTc5NjcxMjQsIm5iZiI6MCwiaWF0IjoxNTU3OTMxMTI0LCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvYXV0aC9yZWFsbXMvdm95YWdlci10ZXN0aW5nIiwiYXVkIjoidm95YWdlci10ZXN0aW5nIiwic3ViIjoiM2Y4MDRiNWEtM2U3Ni00YzI2LTk4ZTYtNDU1ZDNlMzUzZmY3IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidm95YWdlci10ZXN0aW5nIiwiYXV0aF90aW1lIjoxNTU3OTMxMTI0LCJzZXNzaW9uX3N0YXRlIjoiOThiNTM2ODAtODU5MC00MzFmLWFiNzctMDY0MDFmODgzYTY5IiwiYWNyIjoiMSIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInByZWZlcnJlZF91c2VybmFtZSI6ImRldmVsb3BlciJ9.iF3WdY6hwlZIX2bq40fs0GhxG991TqtBEuKbX7A8DMfgOj2QFDyNHGLVzEiJqMal44pmhlWhtOSoVp77ZZ57HdatEYqYaTnc8C8ajA8A1yxOX81D0lFu2jmC3WpKS2H0prrjdPPZyf82YpbYuwYAyiKJMpJSiRC2fGk1Owsg9O6CSj8cFbKfrS4msE1Y90S84qwrDfRYFSFFdsmeTvC71qyj4ZhNqNfPWbIwymlnYJ6xYbmTrZBv2GktXBLd0BnSu5QFoHgjiCxG3cyFV4tCIBpvWjebI6rCUehD6TTIXiW4uVOp9YPWvyZH8WznFdtq36CDb51abWJ8EUquog7M1w'
 
@@ -88,7 +89,7 @@ test('the token object will have hasRole, hasRealmRole and hasPermissions if the
         })
       }
     }
-  }
+  } as unknown as Keycloak.Keycloak
 
   // hardcoded token object that can be used for quick unit testing
   // works with a clientId called 'voyager-testing' and has a client role 'tester'
@@ -112,7 +113,7 @@ test('If the keycloak token validation fails, then onSubscriptionConnect will th
         })
       }
     }
-  }
+  } as unknown as Keycloak.Keycloak
 
   // hardcoded token object that can be used for quick unit testing
   // works with a clientId called 'voyager-testing' and has a client role 'tester'

--- a/test/KeycloakSubscriptionHandler.test.ts
+++ b/test/KeycloakSubscriptionHandler.test.ts
@@ -98,7 +98,7 @@ test('the token object will have hasRole, hasRealmRole and hasPermissions if the
   const subscriptionHandler = new KeycloakSubscriptionHandler({ keycloak: stubKeycloak })
   const connectionParams = { Authorization: tokenString, clientId: 'voyager-testing' }
 
-  const token: Token = await subscriptionHandler.onSubscriptionConnect(connectionParams, {}, {})
+  const token = await subscriptionHandler.onSubscriptionConnect(connectionParams, {}, {}) as Token
   t.truthy(token instanceof Token)
   t.truthy(token.hasRole('tester'))
 })

--- a/test/KeycloakSubscriptionHandler.test.ts
+++ b/test/KeycloakSubscriptionHandler.test.ts
@@ -15,10 +15,10 @@ test('onSubscriptionConnect throws if no connectionParams Provided', async t => 
     }
   } as unknown as Keycloak.Keycloak
 
-  const securityService = new KeycloakSubscriptionHandler({ keycloak: stubKeycloak })
+  const subscriptionHandler = new KeycloakSubscriptionHandler({ keycloak: stubKeycloak })
 
   await t.throwsAsync(async () => {
-    await securityService.onSubscriptionConnect(null, {}, {})
+    await subscriptionHandler.onSubscriptionConnect(null, {}, {})
   }, 'Access Denied - missing connection parameters for Authentication')
 })
 
@@ -33,11 +33,11 @@ test('onSubscriptionConnect throws if no connectionParams is not an object', asy
     }
   } as unknown as Keycloak.Keycloak
 
-  const securityService = new KeycloakSubscriptionHandler({ keycloak: stubKeycloak })
+  const subscriptionHandler = new KeycloakSubscriptionHandler({ keycloak: stubKeycloak })
   const connectionParams = 'not an object'
 
   await t.throwsAsync(async () => {
-    await securityService.onSubscriptionConnect(connectionParams, {}, {})
+    await subscriptionHandler.onSubscriptionConnect(connectionParams, {}, {})
   }, 'Access Denied - missing connection parameters for Authentication')
 })
 
@@ -52,11 +52,11 @@ test('onSubscriptionConnect throws if no Auth provided', async t => {
     }
   } as unknown as Keycloak.Keycloak
 
-  const securityService = new KeycloakSubscriptionHandler({ keycloak: stubKeycloak })
+  const subscriptionHandler = new KeycloakSubscriptionHandler({ keycloak: stubKeycloak })
   const connectionParams = { Authorization: undefined }
 
   await t.throwsAsync(async () => {
-    await securityService.onSubscriptionConnect(connectionParams, {}, {})
+    await subscriptionHandler.onSubscriptionConnect(connectionParams, {}, {})
   }, 'Access Denied - missing Authorization field in connection parameters')
 })
 
@@ -73,10 +73,10 @@ test('onSubscriptionConnect returns a token Object if the keycloak library consi
 
   const tokenString = 'Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJfa29BTUtBcW1xQjcxazNGeDdBQ0xvNXZqMXNoWVZwSkdJM2FScFl4allZIn0.eyJqdGkiOiJjN2UyMzA0NS00NGVmLTQ1ZDItOGY0Yy1jODA4OTlhYzljYzIiLCJleHAiOjE1NTc5NjcxMjQsIm5iZiI6MCwiaWF0IjoxNTU3OTMxMTI0LCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvYXV0aC9yZWFsbXMvdm95YWdlci10ZXN0aW5nIiwiYXVkIjoidm95YWdlci10ZXN0aW5nIiwic3ViIjoiM2Y4MDRiNWEtM2U3Ni00YzI2LTk4ZTYtNDU1ZDNlMzUzZmY3IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidm95YWdlci10ZXN0aW5nIiwiYXV0aF90aW1lIjoxNTU3OTMxMTI0LCJzZXNzaW9uX3N0YXRlIjoiOThiNTM2ODAtODU5MC00MzFmLWFiNzctMDY0MDFmODgzYTY5IiwiYWNyIjoiMSIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInByZWZlcnJlZF91c2VybmFtZSI6ImRldmVsb3BlciJ9.iF3WdY6hwlZIX2bq40fs0GhxG991TqtBEuKbX7A8DMfgOj2QFDyNHGLVzEiJqMal44pmhlWhtOSoVp77ZZ57HdatEYqYaTnc8C8ajA8A1yxOX81D0lFu2jmC3WpKS2H0prrjdPPZyf82YpbYuwYAyiKJMpJSiRC2fGk1Owsg9O6CSj8cFbKfrS4msE1Y90S84qwrDfRYFSFFdsmeTvC71qyj4ZhNqNfPWbIwymlnYJ6xYbmTrZBv2GktXBLd0BnSu5QFoHgjiCxG3cyFV4tCIBpvWjebI6rCUehD6TTIXiW4uVOp9YPWvyZH8WznFdtq36CDb51abWJ8EUquog7M1w'
 
-  const securityService = new KeycloakSubscriptionHandler({ keycloak: stubKeycloak })
+  const subscriptionHandler = new KeycloakSubscriptionHandler({ keycloak: stubKeycloak })
   const connectionParams = { Authorization: tokenString }
 
-  const token = await securityService.onSubscriptionConnect(connectionParams, {}, {})
+  const token = await subscriptionHandler.onSubscriptionConnect(connectionParams, {}, {})
   t.truthy(token instanceof Token)
 })
 
@@ -95,10 +95,10 @@ test('the token object will have hasRole, hasRealmRole and hasPermissions if the
   // works with a clientId called 'voyager-testing' and has a client role 'tester'
   const tokenString = 'Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJfa29BTUtBcW1xQjcxazNGeDdBQ0xvNXZqMXNoWVZwSkdJM2FScFl4allZIn0.eyJqdGkiOiJmMWZjZDdmNS1mMWM0LTQyYWQtYjFmOC00ZWVhNzNiZWU2N2MiLCJleHAiOjE1NTc5Njc4MzksIm5iZiI6MCwiaWF0IjoxNTU3OTMxODM5LCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvYXV0aC9yZWFsbXMvdm95YWdlci10ZXN0aW5nIiwiYXVkIjoidm95YWdlci10ZXN0aW5nIiwic3ViIjoiM2Y4MDRiNWEtM2U3Ni00YzI2LTk4ZTYtNDU1ZDNlMzUzZmY3IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidm95YWdlci10ZXN0aW5nIiwiYXV0aF90aW1lIjoxNTU3OTMxODM5LCJzZXNzaW9uX3N0YXRlIjoiMDQ2YTk4N2QtNmI4NS00Njk5LTllNmUtNGIyYmVlYzBhYzNhIiwiYWNyIjoiMSIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7InZveWFnZXItdGVzdGluZyI6eyJyb2xlcyI6WyJ0ZXN0ZXIiXX0sImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInByZWZlcnJlZF91c2VybmFtZSI6ImRldmVsb3BlciJ9.YjmImGZbs5-s0K1KEYnIedW3peIUz4rORoOUTNFgE2sEKHe2hvvDg48NNybVsJDZc29Al-6OiUw8En5GpschqHHb79GqStEtuJ5T2UZb5sC2B7sX1jAvZAafkxCcOMajEbgS5qVPGoFhDTTej06sGfQwI8h0Igwle86O8IDMbEK-uN_oVa1xKTrFtvsFKekS3Yz3_qSVlmAhOKyYejEg8hkZOvJzHXK9_zsi3Ze6MLq2VCSJE-13UnZuSvdD36FydJQXkZ7elKYqj_HcyPIMAkBuKPhYAXZ9laMo2X4wM6gSIFZXKPeG44eUAGH7estqeG2oXNsdbPaixoNFHHuMqA'
 
-  const securityService = new KeycloakSubscriptionHandler({ keycloak: stubKeycloak })
+  const subscriptionHandler = new KeycloakSubscriptionHandler({ keycloak: stubKeycloak })
   const connectionParams = { Authorization: tokenString, clientId: 'voyager-testing' }
 
-  const token: Token = await securityService.onSubscriptionConnect(connectionParams, {}, {})
+  const token: Token = await subscriptionHandler.onSubscriptionConnect(connectionParams, {}, {})
   t.truthy(token instanceof Token)
   t.truthy(token.hasRole('tester'))
 })
@@ -119,10 +119,10 @@ test('If the keycloak token validation fails, then onSubscriptionConnect will th
   // works with a clientId called 'voyager-testing' and has a client role 'tester'
   const tokenString = 'Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJfa29BTUtBcW1xQjcxazNGeDdBQ0xvNXZqMXNoWVZwSkdJM2FScFl4allZIn0.eyJqdGkiOiJmMWZjZDdmNS1mMWM0LTQyYWQtYjFmOC00ZWVhNzNiZWU2N2MiLCJleHAiOjE1NTc5Njc4MzksIm5iZiI6MCwiaWF0IjoxNTU3OTMxODM5LCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvYXV0aC9yZWFsbXMvdm95YWdlci10ZXN0aW5nIiwiYXVkIjoidm95YWdlci10ZXN0aW5nIiwic3ViIjoiM2Y4MDRiNWEtM2U3Ni00YzI2LTk4ZTYtNDU1ZDNlMzUzZmY3IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidm95YWdlci10ZXN0aW5nIiwiYXV0aF90aW1lIjoxNTU3OTMxODM5LCJzZXNzaW9uX3N0YXRlIjoiMDQ2YTk4N2QtNmI4NS00Njk5LTllNmUtNGIyYmVlYzBhYzNhIiwiYWNyIjoiMSIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7InZveWFnZXItdGVzdGluZyI6eyJyb2xlcyI6WyJ0ZXN0ZXIiXX0sImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInByZWZlcnJlZF91c2VybmFtZSI6ImRldmVsb3BlciJ9.YjmImGZbs5-s0K1KEYnIedW3peIUz4rORoOUTNFgE2sEKHe2hvvDg48NNybVsJDZc29Al-6OiUw8En5GpschqHHb79GqStEtuJ5T2UZb5sC2B7sX1jAvZAafkxCcOMajEbgS5qVPGoFhDTTej06sGfQwI8h0Igwle86O8IDMbEK-uN_oVa1xKTrFtvsFKekS3Yz3_qSVlmAhOKyYejEg8hkZOvJzHXK9_zsi3Ze6MLq2VCSJE-13UnZuSvdD36FydJQXkZ7elKYqj_HcyPIMAkBuKPhYAXZ9laMo2X4wM6gSIFZXKPeG44eUAGH7estqeG2oXNsdbPaixoNFHHuMqA'
 
-  const securityService = new KeycloakSubscriptionHandler({ keycloak: stubKeycloak })
+  const subscriptionHandler = new KeycloakSubscriptionHandler({ keycloak: stubKeycloak })
   const connectionParams = { Authorization: tokenString, clientId: 'voyager-testing' }
 
   await t.throwsAsync(async () => {
-    await securityService.onSubscriptionConnect(connectionParams, {}, {})
+    await subscriptionHandler.onSubscriptionConnect(connectionParams, {}, {})
   }, `Access Denied - ${new Error(errorMsg)}`)  
 })

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,6 +1,7 @@
 import test from 'ava'
 import sinon from 'sinon'
 
+import Keycloak from 'keycloak-connect'
 import { GraphQLSchema } from 'graphql'
 import { VisitableSchemaType } from 'graphql-tools/dist/schemaVisitor'
 import { AuthDirective } from '../src/directives/schemaDirectiveVisitors'
@@ -42,7 +43,8 @@ test('happy path: context.kauth.isAuthenticated() is called, then original resol
         }
       }
     }
-  }
+  } as Keycloak.GrantedRequest
+
   const context = {
     request: req,
     kauth: new KeycloakContext({ req })
@@ -86,7 +88,8 @@ test('resolver will throw if context.kauth is not present', async (t) => {
         }
       }
     }
-  }
+  } as Keycloak.GrantedRequest
+
   const context = {
     request: req
   }
@@ -116,7 +119,7 @@ test('resolver will throw if context.kauth present but context.kauth.isAuthentic
 
   const root = {}
   const args = {}
-  const req = {}
+  const req = {} as Keycloak.GrantedRequest
 
   const context = {
     request: req,

--- a/test/hasRole.test.ts
+++ b/test/hasRole.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava'
 
+import Keycloak from 'keycloak-connect'
 import { GraphQLSchema } from 'graphql'
 import { VisitableSchemaType } from 'graphql-tools/dist/schemaVisitor'
 import { HasRoleDirective } from '../src/directives/schemaDirectiveVisitors'
@@ -50,7 +51,8 @@ test('context.auth.hasRole() is called', async (t) => {
         }
       }
     }
-  }
+  } as Keycloak.GrantedRequest
+
   const context = {
     request: req,
     kauth: new KeycloakContext({ req })
@@ -99,7 +101,8 @@ test('visitFieldDefinition accepts an array of roles', async (t) => {
         }
       }
     }
-  }
+  } as Keycloak.GrantedRequest
+
   const context = {
     request: req,
     kauth: new KeycloakContext({ req })
@@ -135,7 +138,7 @@ test('if there is no authentication, then an error is returned and the original 
 
   const root = {}
   const args = {}
-  const req = {}
+  const req = {} as Keycloak.GrantedRequest
   const context = {
     request: req,
     kauth: new KeycloakContext({ req })
@@ -186,7 +189,8 @@ test('if token does not have the required role, then an error is returned and th
         }
       }
     }
-  }
+  } as Keycloak.GrantedRequest
+
   const context = {
     request: req,
     kauth: new KeycloakContext({ req })
@@ -261,7 +265,8 @@ test('context.auth.hasRole() works even if request is not supplied in context', 
         }
       }
     }
-  }
+  } as Keycloak.GrantedRequest
+
   const context = {
     kauth: new KeycloakContext({ req })
   }


### PR DESCRIPTION
This PR adds some really nice subscriptions refinements.

Take a look at the two examples provided.

* subscriptions.js - demonstrates the basic setup needed for subscriptions. In this mode, all subscriptions must be authenticated

* subscriptions_advanced.js - demonstrates how we can use `new KeycloakSubscriptionHandler({protect: false})` so that `onSubscriptionConnect` will not automatically throw an error if no auth related connectionParams are provided. This makes it possible to add authentication/authorization on individual subscription resolvers. For example you could have both public and private subscriptions.

In both scenarios, `context.kauth` in the subscription resolvers will work the exact same as in regular resolvers thanks to the `KeycloakSubscriptionContext` class. (`KeycloakSubscriptionContext` and `KeycloakContext` are now extensions of the `KeycloakContextBase` which provides the common functionality. This could also be used in future if we needed to support context from something that isn't express).

These improvements in how the context is built means that it is now possible to reuse the existing `hasRole` and `auth` resolver middlewares on subscription resolvers. Here's an example:

```js
const { auth } = require('keycloak-connect-graphql')

const resolvers = {
  Subscription: {
    taskAdded: {
      subscribe: auth(() => pubsub.asyncIterator(TOPIC))
    },
    taskDeleted: {
      subscribe: hasRole('admin')(() => pubsub.asyncIterator(TOPIC))
    }
  }
}
```