### PR TITLE
feat: subscriptions refinements

### DIFF
--- a/examples/authResolvers.js
+++ b/examples/authResolvers.js
@@ -1,40 +1,19 @@
-const fs = require('fs')
-const path = require('path')
 const express = require('express')
-const session = require('express-session')
-const Keycloak = require('keycloak-connect')
 const { ApolloServer, gql } = require('apollo-server-express')
+const { configureKeycloak } = require('./common')
 
-const { KeycloakContext, KeycloakTypeDefs, auth, hasRole } = require('../')
+const {
+  KeycloakContext,
+  KeycloakTypeDefs,
+  KeycloakSchemaDirectives
+} = require('../')
 
 const app = express()
 
-const memoryStore = new session.MemoryStore()
-
 const graphqlPath = '/graphql'
 
-
-app.use(session({
-  secret: process.env.SESSION_SECRET_STRING || 'this should be a long secret',
-  resave: false,
-  saveUninitialized: true,
-  store: memoryStore
-}))
-
-const keycloakConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, './config/keycloak.json')))
-
-const keycloak = new Keycloak({
-  store: memoryStore
-}, keycloakConfig)
-
-// Install general keycloak middleware
-app.use(keycloak.middleware({
-  admin: graphqlPath
-}))
-
-// Protect the main route for all graphql services
-// Disable unauthenticated access
-app.use(graphqlPath, keycloak.middleware())
+// perform the standard keycloak-connect middleware setup on our app
+configureKeycloak(app, graphqlPath)
 
 const typeDefs = gql`
   type Query {
@@ -62,7 +41,6 @@ const resolvers = {
   }
 }
 
-// Initialize the voyager server with our schema and context
 const options ={
   typeDefs: [KeycloakTypeDefs, typeDefs],
   resolvers,

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,41 +1,19 @@
-const fs = require('fs')
-const path = require('path')
 const express = require('express')
-const session = require('express-session')
-const Keycloak = require('keycloak-connect')
-
-const { KeycloakContext, KeycloakTypeDefs, KeycloakSchemaDirectives } = require('../')
-
 const { ApolloServer, gql } = require('apollo-server-express')
+const { configureKeycloak } = require('./common')
 
-const keycloakConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, './config/keycloak.json')))
+const {
+  KeycloakContext,
+  KeycloakTypeDefs,
+  KeycloakSchemaDirectives
+} = require('../')
 
 const app = express()
 
-const memoryStore = new session.MemoryStore()
-
 const graphqlPath = '/graphql'
 
-
-app.use(session({
-  secret: process.env.SESSION_SECRET_STRING || 'this should be a long secret',
-  resave: false,
-  saveUninitialized: true,
-  store: memoryStore
-}))
-
-const keycloak = new Keycloak({
-  store: memoryStore
-}, keycloakConfig)
-
-// Install general keycloak middleware
-app.use(keycloak.middleware({
-  admin: graphqlPath
-}))
-
-// Protect the main route for all graphql services
-// Disable unauthenticated access
-app.use(graphqlPath, keycloak.protect())
+// perform the standard keycloak-connect middleware setup on our app
+configureKeycloak(app, graphqlPath)
 
 const typeDefs = gql`
   type Query {
@@ -55,8 +33,6 @@ const resolvers = {
     }
   }
 }
-
-// Initialize the voyager server with our schema and context
 
 const server = new ApolloServer({
   typeDefs: [KeycloakTypeDefs, typeDefs],

--- a/examples/common.js
+++ b/examples/common.js
@@ -1,0 +1,37 @@
+const fs = require('fs')
+const path = require('path')
+const session = require('express-session')
+const Keycloak = require('keycloak-connect')
+
+function configureKeycloak(app, graphqlPath) {
+
+  const keycloakConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, './config/keycloak.json')))
+
+  const memoryStore = new session.MemoryStore()
+
+  app.use(session({
+    secret: process.env.SESSION_SECRET_STRING || 'this should be a long secret',
+    resave: false,
+    saveUninitialized: true,
+    store: memoryStore
+  }))
+
+  const keycloak = new Keycloak({
+    store: memoryStore
+  }, keycloakConfig)
+
+  // Install general keycloak middleware
+  app.use(keycloak.middleware({
+    admin: graphqlPath
+  }))
+
+  // Protect the main route for all graphql services
+  // Disable unauthenticated access
+  app.use(graphqlPath, keycloak.middleware())
+
+  return { keycloak }
+}
+
+module.exports = {
+  configureKeycloak
+}

--- a/examples/private_and_public.js
+++ b/examples/private_and_public.js
@@ -1,40 +1,19 @@
-const fs = require('fs')
-const path = require('path')
 const express = require('express')
-const session = require('express-session')
-const Keycloak = require('keycloak-connect')
 const { ApolloServer, gql } = require('apollo-server-express')
+const { configureKeycloak } = require('./common')
 
-const { KeycloakContext, KeycloakTypeDefs, KeycloakSchemaDirectives } = require('../')
+const {
+  KeycloakContext,
+  KeycloakTypeDefs,
+  KeycloakSchemaDirectives
+} = require('../')
 
 const app = express()
 
-const memoryStore = new session.MemoryStore()
-
 const graphqlPath = '/graphql'
 
-
-app.use(session({
-  secret: process.env.SESSION_SECRET_STRING || 'this should be a long secret',
-  resave: false,
-  saveUninitialized: true,
-  store: memoryStore
-}))
-
-const keycloakConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, './config/keycloak.json')))
-
-const keycloak = new Keycloak({
-  store: memoryStore
-}, keycloakConfig)
-
-// Install general keycloak middleware
-app.use(keycloak.middleware({
-  admin: graphqlPath
-}))
-
-// Protect the main route for all graphql services
-// Disable unauthenticated access
-app.use(graphqlPath, keycloak.middleware())
+// perform the standard keycloak-connect middleware setup on our app
+configureKeycloak(app, graphqlPath)
 
 const typeDefs = gql`
   type Query {
@@ -62,7 +41,6 @@ const resolvers = {
   }
 }
 
-// Initialize the voyager server with our schema and context
 const options ={
   typeDefs: [KeycloakTypeDefs, typeDefs],
   schemaDirectives: KeycloakSchemaDirectives,

--- a/examples/subscriptions.js
+++ b/examples/subscriptions.js
@@ -1,0 +1,93 @@
+const express = require('express')
+const { PubSub } = require('graphql-subscriptions')
+const { execute, subscribe } = require('graphql')
+const { SubscriptionServer } = require('subscriptions-transport-ws')
+
+const { ApolloServer, gql } = require('apollo-server-express')
+
+const { configureKeycloak } = require('./common')
+
+const { 
+  KeycloakContext,
+  KeycloakSubscriptionContext,
+  KeycloakTypeDefs,
+  KeycloakSchemaDirectives,
+  KeycloakSubscriptionHandler
+} = require('../')
+
+
+const app = express()
+
+const graphqlPath = '/graphql'
+
+// perform the standard keycloak-connect middleware setup on our app
+// return the initialized keycloak object
+const { keycloak } = configureKeycloak(app, graphqlPath)
+
+const pubsub = new PubSub()
+
+// set up the pubsub to publish a message every 2 seconds
+const TOPIC = 'HELLO'
+setInterval(() => {
+  pubsub.publish(TOPIC, { testSubscription: `tesing... ${Date.now()}`})
+}, 2000)
+
+const typeDefs = gql`
+  type Query {
+    hello: String!
+  }
+
+  type Subscription {
+    testSubscription: String!
+  }
+`
+
+const resolvers = {
+  Query: {
+    hello: (obj, args, context, info) => {
+      return `Hello world`
+    }
+  },
+  Subscription: {
+    testSubscription: {
+      subscribe: () => pubsub.asyncIterator(TOPIC)
+    }
+  }
+}
+
+const server = new ApolloServer({
+  typeDefs: [KeycloakTypeDefs, typeDefs],
+  schemaDirectives: KeycloakSchemaDirectives,
+  resolvers,
+  context: ({ req }) => {
+    return {
+      kauth: new KeycloakContext({ req })
+    }
+  }
+})
+
+server.applyMiddleware({ app })
+
+const port = 4000
+
+const httpServer = app.listen({ port }, () => {
+  console.log(`🚀 Server ready at http://localhost:${port}${server.graphqlPath}`)
+
+  // Initialize the keycloak subscription handler passing in our keycloak instance
+  const keycloakSubscriptionHandler = new KeycloakSubscriptionHandler({ keycloak })
+  new SubscriptionServer({
+    execute,
+    subscribe,
+    schema: server.schema,
+    onConnect: async (connectionParams, websocket, connectionContext) => {
+      const token = await keycloakSubscriptionHandler.onSubscriptionConnect(connectionParams)
+      return {
+        kauth: new KeycloakSubscriptionContext(token)
+      }
+    }
+  }, {
+    server: httpServer,
+    path: graphqlPath
+  })
+})
+

--- a/examples/subscriptions_advanced.js
+++ b/examples/subscriptions_advanced.js
@@ -1,0 +1,104 @@
+const express = require('express')
+const { PubSub } = require('graphql-subscriptions')
+const { execute, subscribe } = require('graphql')
+const { SubscriptionServer } = require('subscriptions-transport-ws')
+
+const { ApolloServer, gql } = require('apollo-server-express')
+
+const { configureKeycloak } = require('./common')
+
+const { 
+  KeycloakContext,
+  KeycloakSubscriptionContext,
+  KeycloakTypeDefs,
+  KeycloakSchemaDirectives,
+  KeycloakSubscriptionHandler,
+  auth
+} = require('../')
+
+
+const app = express()
+
+const graphqlPath = '/graphql'
+
+// perform the standard keycloak-connect middleware setup on our app
+// return the initialized keycloak object
+const { keycloak } = configureKeycloak(app, graphqlPath)
+
+const pubsub = new PubSub()
+
+// set up the pubsub to publish a message every 2 seconds
+const TOPIC = 'HELLO'
+setInterval(() => {
+  pubsub.publish(TOPIC, { 
+    testSubscription: `tesing... ${Date.now()}`,
+    testSubscriptionProtected: `tesing... ${Date.now()}`
+  })
+}, 2000)
+
+
+const typeDefs = gql`
+  type Query {
+    hello: String!
+  }
+
+  type Subscription {
+    testSubscription: String!
+    testSubscriptionProtected: String!
+  }
+`
+
+const resolvers = {
+  Query: {
+    hello: (obj, args, context, info) => {
+      return `Hello world`
+    }
+  },
+  Subscription: {
+    testSubscription: {
+      subscribe: () => pubsub.asyncIterator(TOPIC)
+    },
+    testSubscriptionProtected: {
+      subscribe: auth(() => pubsub.asyncIterator(TOPIC))
+    }
+  }
+}
+
+const server = new ApolloServer({
+  typeDefs: [KeycloakTypeDefs, typeDefs],
+  schemaDirectives: KeycloakSchemaDirectives,
+  resolvers,
+  context: ({ req }) => {
+    return {
+      kauth: new KeycloakContext({ req })
+    }
+  }
+})
+
+server.applyMiddleware({ app })
+
+const port = 4000
+
+const httpServer = app.listen({ port }, () => {
+  console.log(`🚀 Server ready at http://localhost:${port}${server.graphqlPath}`)
+
+  // Initialize the keycloak subscription handler passing in our keycloak instance
+  // protect: false means that subscriptions will not fail
+  // if the token is not provided by the client in connectionParams
+  const keycloakSubscriptionHandler = new KeycloakSubscriptionHandler({ keycloak, protect: false })
+  new SubscriptionServer({
+    execute,
+    subscribe,
+    schema: server.schema,
+    onConnect: async (connectionParams, websocket, connectionContext) => {
+      const token = await keycloakSubscriptionHandler.onSubscriptionConnect(connectionParams)
+      return {
+        kauth: new KeycloakSubscriptionContext(token)
+      }
+    }
+  }, {
+    server: httpServer,
+    path: graphqlPath
+  })
+})
+

--- a/package.json
+++ b/package.json
@@ -42,9 +42,11 @@
     "coveralls": "3.0.4",
     "express": "4.17.1",
     "graphql": "14.4.1",
+    "graphql-subscriptions": "^1.1.0",
     "keycloak-request-token": "^0.1.0",
     "nyc": "14.1.1",
     "sinon": "^7.3.2",
+    "subscriptions-transport-ws": "^0.9.16",
     "ts-node": "8.3.0",
     "tslint": "5.18.0",
     "typescript": "3.5.2"

--- a/scripts/getToken.js
+++ b/scripts/getToken.js
@@ -12,7 +12,7 @@ const settings = {
 tokenRequester(baseUrl, settings)
   .then((token) => {
     const headers = {
-      Authorization: `Bearer ${token}`
+      Authorization: `Bearer ${token}`, clientId: settings.client_id
     }
     console.log(JSON.stringify(headers))
   }).catch((err) => {

--- a/src/KeycloakContext.ts
+++ b/src/KeycloakContext.ts
@@ -1,6 +1,44 @@
 import { AuthContextProvider } from './api'
 import Keycloak from 'keycloak-connect'
 
+export class KeycloakContextBase implements AuthContextProvider {
+  public readonly accessToken: Keycloak.Token | undefined
+
+  constructor (token?: Keycloak.Token) {
+    this.accessToken = token
+  }
+
+  /**
+   * returns true if a valid, non expired access token is present
+   */
+  public isAuthenticated (): boolean {
+    return (this.accessToken && !this.accessToken.isExpired()) ? true : false 
+  }
+
+  /**
+   * 
+   * Checks that the authenticated keycloak user has the role.
+   * If the user has the role, the next resolver is called.
+   * If the user does not have the role, an error is thrown.
+   * 
+   * If an array of roles is passed, it checks that the user has at least one of the roles
+   * 
+   * By default, hasRole checks for keycloak client roles.
+   * Example: `hasRole('admin')` will check the logged in user has the client role named admin.
+   * 
+   * It also is possible to check for realm roles and application roles.
+   * * `hasRole('realm:admin')` will check the logged in user has the admin realm role
+   * * `hasRole('some-other-app:admin')` will check the loged in user has the admin realm role in a different application
+   * 
+   * 
+   * @param role the role or array of roles to check
+   */
+  public hasRole (role: string): boolean {
+    //@ts-ignore
+    return this.isAuthenticated() && this.accessToken.hasRole(role)
+  }
+}
+
 /**
  * Context builder class that adds the Keycloak token from `req.kauth` into the GraphQL context.
  * This class *must* be added to the context under `context.kauth`.
@@ -22,22 +60,49 @@ import Keycloak from 'keycloak-connect'
  * ```
  * Note: This class gets the token details from `req.kauth` so you must ensure that the keycloak middleware
  * is installed on the graphql endpoint
+ * 
  */
-export class KeycloakContext implements AuthContextProvider {
+export class KeycloakContext extends KeycloakContextBase implements AuthContextProvider {
   public readonly request: Keycloak.GrantedRequest
   public readonly accessToken: Keycloak.Token | undefined
 
   constructor ({ req }: { req: Keycloak.GrantedRequest }) {
+    const token = (req && req.kauth && req.kauth.grant) ? req.kauth.grant.access_token : undefined
+    super(token)
     this.request = req
-    this.accessToken = (req && req.kauth && req.kauth.grant) ? req.kauth.grant.access_token : undefined
   }
+}
 
-  public isAuthenticated (): boolean {
-    return (this.accessToken && !this.accessToken.isExpired()) ? true : false 
-  }
-
-  public hasRole (role: string): boolean {
-    //@ts-ignore
-    return this.isAuthenticated() && this.accessToken.hasRole(role)
+/**
+ * Context builder class that extends the original KeycloakContext object
+ * but is used for building the context for subscriptions
+ * 
+ * example usage: 
+ * 
+ * ```javascript
+ * const keycloakSubscriptionHandler = new KeycloakSubscriptionHandler({ keycloak })
+ *   new SubscriptionServer({
+ *     execute,
+ *     subscribe,
+ *     schema: server.schema,
+ *     onConnect: async (connectionParams, websocket, connectionContext) => {
+ *       const token = await keycloakSubscriptionHandler.onSubscriptionConnect(connectionParams)
+ *       return {
+ *         kauth: new KeycloakSubscriptionContext(token)
+ *       }
+ *     }
+ *   }, {
+ *     server,
+ *     path: '/graphql'
+ *   })
+ * ```
+ */
+export class KeycloakSubscriptionContext extends KeycloakContextBase {
+  /**
+   * 
+   * @param token a keycloak token object
+   */
+  constructor(token: Keycloak.Token) {
+    super(token)
   }
 }

--- a/src/KeycloakSubscriptionHandler.ts
+++ b/src/KeycloakSubscriptionHandler.ts
@@ -2,20 +2,65 @@ import Keycloak from './KeycloakTypings'
 import { Token } from './KeycloakToken'
 import { KeycloakSubscriptionHandlerOptions } from './api'
 
+/**
+ * Provides the onSubscriptionConnect function that is used to validate incoming
+ * websocket connections for subscriptions.
+ * 
+ * Parses and validates the keycloak token sent by the client in the connectionParams
+ * 
+ * Example usage:
+ * 
+ * ```javascript
+ * const server = app.listen({ port }, () => {
+ *   console.log(`🚀 Server ready at http://localhost:${port}${server.graphqlPath}`)
+ *
+ *   const keycloakSubscriptionHandler = new KeycloakSubscriptionHandler({ keycloak })
+ *   new SubscriptionServer({
+ *     execute,
+ *     subscribe,
+ *     schema: server.schema,
+ *     onConnect: async (connectionParams, websocket, connectionContext) => {
+ *       const token = await keycloakSubscriptionHandler.onSubscriptionConnect(connectionParams)
+ *       return {
+ *         kauth: new KeycloakSubscriptionContext(token)
+ *       }
+ *     }
+ *   }, {
+ *     server,
+ *     path: '/graphql'
+ *   })
+ *})
+ *```
+ */
 export class KeycloakSubscriptionHandler {
 
   public keycloak: Keycloak.Keycloak
+  public protect?: boolean
 
+  /**
+   * 
+   * @param options 
+   */
   constructor (options: KeycloakSubscriptionHandlerOptions) {
     if (!options.keycloak) {
       throw new Error('missing keycloak instance in options')
     }
     this.keycloak = options.keycloak
+    this.protect = (options.protect !== null && options.protect !== undefined) ? options.protect : true
   }
 
-  public async onSubscriptionConnect(connectionParams: any, webSocket: any, context: any): Promise<any> {
+  /**
+   * 
+   * @param connectionParams 
+   * @param webSocket 
+   * @param context 
+   */
+  public async onSubscriptionConnect(connectionParams: any, webSocket: any, context: any): Promise<Keycloak.Token | undefined | Error> {
     if (!connectionParams || typeof connectionParams !== 'object') {
-      throw new Error('Access Denied - missing connection parameters for Authentication')
+      if (this.protect === true) {
+        throw new Error('Access Denied - missing connection parameters for Authentication')
+      }
+      return
     }
     const header = connectionParams.Authorization
                   || connectionParams.authorization
@@ -23,11 +68,15 @@ export class KeycloakSubscriptionHandler {
                   || connectionParams.auth
     const clientId = connectionParams.clientId
     if (!header) {
-      throw new Error('Access Denied - missing Authorization field in connection parameters')
+      if (this.protect === true) {
+        throw new Error('Access Denied - missing Authorization field in connection parameters')
+      }
+      return
     }
     const token = this.getBearerTokenFromHeader(header, clientId)
     try {
       await this.keycloak.grantManager.validateToken(token, 'Bearer')
+      //@ts-ignore
       return token
     } catch (e) {
       throw new Error(`Access Denied - ${e}`)

--- a/src/KeycloakSubscriptionHandler.ts
+++ b/src/KeycloakSubscriptionHandler.ts
@@ -42,7 +42,7 @@ export class KeycloakSubscriptionHandler {
    * @param options 
    */
   constructor (options: KeycloakSubscriptionHandlerOptions) {
-    if (!options.keycloak) {
+    if (!options || !options.keycloak) {
       throw new Error('missing keycloak instance in options')
     }
     this.keycloak = options.keycloak

--- a/src/api/KeycloakSubscriptionHandlerOptions.ts
+++ b/src/api/KeycloakSubscriptionHandlerOptions.ts
@@ -1,5 +1,21 @@
 import Keycloak from '../KeycloakTypings'
 
 export interface KeycloakSubscriptionHandlerOptions {
-  keycloak: Keycloak.Keycloak
+  
+  /**
+   * The initialized keycloak object from keycloak-connect
+   */
+  keycloak: Keycloak.Keycloak,
+
+  /**
+   * If true, then all subscriptions must be authenticated. 
+   * Clients that do not supply the correct connectionParams will be blocked
+   * 
+   * If false, then the connectionParams will still be parsed and validated
+   * but unauthenticated clients (i.e. no connectionParams) will not be immediately blocked.
+   * This means it can be decided on an individual subscription level.
+   * Allowing for publicly and non publicly accessible subscriptions
+   * 
+   */
+  protect?: boolean
 }

--- a/test/KeycloakContext.test.ts
+++ b/test/KeycloakContext.test.ts
@@ -1,9 +1,38 @@
 import test from 'ava'
 import Keycloak from 'keycloak-connect'
 
-import { KeycloakContext } from '../src/KeycloakContext'
+import { KeycloakContext, KeycloakContextBase, KeycloakSubscriptionContext } from '../src/KeycloakContext'
 
-test('AuthContextProvider accessToken is the access_token in req.kauth', (t) => {
+test('KeycloakContextBase accessToken is the access_token in req.kauth', (t) => {
+  const token = {
+    hasRole: (role: string) => {
+      return true
+    },
+    isExpired: () => {
+      return false
+    }
+  } as Keycloak.Token
+
+  const provider = new KeycloakContextBase(token)
+  t.deepEqual(provider.accessToken, token)
+})
+
+test('KeycloakSubscriptionContext accessToken is the access_token in req.kauth', (t) => {
+
+  const token = {
+    hasRole: (role: string) => {
+      return true
+    },
+    isExpired: () => {
+      return false
+    }
+  } as Keycloak.Token
+
+  const provider = new KeycloakSubscriptionContext(token)
+  t.deepEqual(provider.accessToken, token)
+})
+
+test('KeycloakContext accessToken is the access_token in req.kauth', (t) => {
 
   const req = {
     kauth: {
@@ -25,7 +54,7 @@ test('AuthContextProvider accessToken is the access_token in req.kauth', (t) => 
   t.deepEqual(provider.accessToken, token)
 })
 
-test('AuthContextProvider hasRole calls hasRole in the access_token', (t) => {
+test('KeycloakContext hasRole calls hasRole in the access_token', (t) => {
   t.plan(2)
   const req = {
     kauth: {
@@ -47,7 +76,7 @@ test('AuthContextProvider hasRole calls hasRole in the access_token', (t) => {
   t.truthy(provider.hasRole(''))
 })
 
-test('AuthContextProvider.isAuthenticated is true when token is defined and isExpired returns false', (t) => {
+test('KeycloakContext.isAuthenticated is true when token is defined and isExpired returns false', (t) => {
   const req = {
     kauth: {
       grant: {
@@ -67,7 +96,7 @@ test('AuthContextProvider.isAuthenticated is true when token is defined and isEx
   t.truthy(provider.isAuthenticated())
 })
 
-test('AuthContextProvider.isAuthenticated is false when token is defined but isExpired returns true', (t) => {
+test('KeycloakContext.isAuthenticated is false when token is defined but isExpired returns true', (t) => {
   const req = {
     kauth: {
       grant: {
@@ -87,7 +116,7 @@ test('AuthContextProvider.isAuthenticated is false when token is defined but isE
   t.false(provider.isAuthenticated())
 })
 
-test('AuthContextProvider.hasRole is false if token is expired', (t) => {
+test('KeycloakContext.hasRole is false if token is expired', (t) => {
   const req = {
     kauth: {
       grant: {

--- a/test/KeycloakSubscriptionHandler.test.ts
+++ b/test/KeycloakSubscriptionHandler.test.ts
@@ -98,7 +98,7 @@ test('the token object will have hasRole, hasRealmRole and hasPermissions if the
   const subscriptionHandler = new KeycloakSubscriptionHandler({ keycloak: stubKeycloak })
   const connectionParams = { Authorization: tokenString, clientId: 'voyager-testing' }
 
-  const token: Token = await subscriptionHandler.onSubscriptionConnect(connectionParams, {}, {})
+  const token = await subscriptionHandler.onSubscriptionConnect(connectionParams, {}, {}) as Token
   t.truthy(token instanceof Token)
   t.truthy(token.hasRole('tester'))
 })

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -64,6 +64,48 @@ test('happy path: context.kauth.isAuthenticated() is called, then original resol
   t.truthy(resolverSpy.called)
 })
 
+test('context.kauth.isAuthenticated() is called, even if field has no resolver', async (t) => {
+  const directive = createHasRoleDirective()
+
+  const field = {
+    name: 'testField'
+  }
+
+  directive.visitFieldDefinition(field)
+
+  const root = {}
+  const args = {}
+  const req = {
+    kauth: {
+      grant: {
+        access_token: {
+          isExpired: () => {
+            return false
+          }
+        }
+      }
+    }
+  } as Keycloak.GrantedRequest
+
+  const context = {
+    request: req,
+    kauth: new KeycloakContext({ req })
+  }
+
+  const isAuthenticatedSpy = sinon.spy(context.kauth, 'isAuthenticated')
+
+  const info = {
+    parentType: {
+      name: 'testParent'
+    }
+  }
+
+  //@ts-ignore
+  await field.resolve(root, args, context, info)
+  
+  t.truthy(isAuthenticatedSpy.called)
+})
+
 test('resolver will throw if context.kauth is not present', async (t) => {
   const directive = createHasRoleDirective()
 

--- a/test/hasRole.test.ts
+++ b/test/hasRole.test.ts
@@ -91,7 +91,6 @@ test('visitFieldDefinition accepts an array of roles', async (t) => {
       grant: {
         access_token: {
           hasRole: (role: string) => {
-            t.log(`checking has role ${role}`)
             t.pass()
             return (role === 'baz') // this makes sure it doesn't return true instantly
           },

--- a/test/hasRole.test.ts
+++ b/test/hasRole.test.ts
@@ -67,6 +67,54 @@ test('context.auth.hasRole() is called', async (t) => {
   await field.resolve(root, args, context, info)
 })
 
+test('hasRole works on fields that have no resolvers. context.auth.hasRole() is called', async (t) => {
+  t.plan(2)
+  const directiveArgs = {
+    role: 'admin'
+  }
+
+  const directive = createHasRoleDirective(directiveArgs)
+
+  const field = {
+    name: 'testField'
+  }
+
+  directive.visitFieldDefinition(field)
+
+  const root = {}
+  const args = {}
+  const req = {
+    kauth: {
+      grant: {
+        access_token: {
+          hasRole: (role: string) => {
+            t.pass()
+            t.deepEqual(role, directiveArgs.role)
+            return true
+          },
+          isExpired: () => {
+            return false
+          }
+        }
+      }
+    }
+  } as Keycloak.GrantedRequest
+
+  const context = {
+    request: req,
+    kauth: new KeycloakContext({ req })
+  }
+
+  const info = {
+    parentType: {
+      name: 'testParent'
+    }
+  }
+
+  //@ts-ignore
+  await field.resolve(root, args, context, info)
+})
+
 test('visitFieldDefinition accepts an array of roles', async (t) => {
   t.plan(4)
   const directiveArgs = {


### PR DESCRIPTION
This PR adds some really nice subscriptions refinements.

Take a look at the two examples provided.

* subscriptions.js - demonstrates the basic setup needed for subscriptions. In this mode, all subscriptions must be authenticated

* subscriptions_advanced.js - demonstrates how we can use `new KeycloakSubscriptionHandler({protect: false})` so that `onSubscriptionConnect` will not automatically throw an error if no auth related connectionParams are provided. This makes it possible to add authentication/authorization on individual subscription resolvers. For example you could have both public and private subscriptions.

In both scenarios, `context.kauth` in the subscription resolvers will work the exact same as in regular resolvers thanks to the `KeycloakSubscriptionContext` class. (`KeycloakSubscriptionContext` and `KeycloakContext` are now extensions of the `KeycloakContextBase` which provides the common functionality. This could also be used in future if we needed to support context from something that isn't express).

These improvements in how the context is built means that it is now possible to reuse the existing `hasRole` and `auth` resolver middlewares on subscription resolvers. Here's an example:

```js
const { auth } = require('keycloak-connect-graphql')

const resolvers = {
  Subscription: {
    taskAdded: {
      subscribe: auth(() => pubsub.asyncIterator(TOPIC))
    },
    taskDeleted: {
      subscribe: hasRole('admin')(() => pubsub.asyncIterator(TOPIC))
    }
  }
}
```