### PR TITLE
fix: remove dependency on joi, use our own validation logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,23 +24,19 @@
   },
   "dependencies": {
     "apollo-server-express": "2.6.7",
-    "express-session": "1.16.2",
     "graphql-tools": "4.0.5",
-    "joi": "14.3.1",
-    "keycloak-connect": "6.0.1",
-    "pino": "5.12.6"
+    "keycloak-connect": "6.0.1"
   },
   "devDependencies": {
     "@types/express-session": "1.15.13",
     "@types/graphql": "14.2.2",
-    "@types/joi": "14.3.3",
     "@types/keycloak-connect": "4.5.1",
     "@types/node": "10.14.10",
-    "@types/pino": "5.20.0",
     "@types/sinon": "^7.0.13",
     "ava": "2.1.0",
     "coveralls": "3.0.4",
     "express": "4.17.1",
+    "express-session": "1.16.2",
     "graphql": "14.4.1",
     "keycloak-request-token": "^0.1.0",
     "nyc": "14.1.1",

--- a/src/directives/schemaDirectiveVisitors.ts
+++ b/src/directives/schemaDirectiveVisitors.ts
@@ -36,13 +36,16 @@ export class HasRoleDirective extends SchemaDirectiveVisitor {
 
   public visitFieldDefinition (field: any) {
     const { resolve = defaultFieldResolver } = field
-    const roles = this.validateArgs(this.args)
+    const roles = this.parseAndValidateArgs(this.args)
     field.resolve = hasRole(roles)(resolve)
   }
 
-  // validate a potential string or array of values
-  // if an array is provided, cast all values to strings
-  public validateArgs (args: {[name: string]: any}): Array<string> {
+  /**
+   * 
+   * validate a potential string or array of values
+   * if an array is provided, cast all values to strings
+   */
+  public parseAndValidateArgs (args: {[name: string]: any}): Array<string> {
     const keys = Object.keys(args)
 
     if (keys.length === 1 && keys[0] === 'role') {

--- a/test/hasRole.test.ts
+++ b/test/hasRole.test.ts
@@ -307,7 +307,7 @@ test('hasRole role arg can be an array, non string values will be converted, vis
     name: 'testField'
   }
 
-  const validateSpy = sinon.spy(directive, 'validateArgs')
+  const validateSpy = sinon.spy(directive, 'parseAndValidateArgs')
   
   directive.visitFieldDefinition(field)
 


### PR DESCRIPTION
This just replaces the function that validates the args that goes into `@hasRole()`. Thankfully the existing tests helped me ensure the exact same behaviour was kept. I also added a couple of more tests too. `joi` is a really nice library but it is a heavyweight solution for such a small piece of validation.