### PR TITLE
fix: subscriptions using correct clientId for token

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,15 +259,14 @@ The GraphQL client should provide the following `connectionParams` when attempti
 
 ```json
 {
-  "Authorization": "Bearer <keycloak token value>",
-  "clientId": "<name of the clientId assigned to the application in Keycloak>"
+  "Authorization": "Bearer <keycloak token value>"
 }
 ```
 
 The example code shows how it could be done on the client side using Apollo Client.
 
 ```js
-import Keycloak from "keycloak-js"
+import Keycloak from 'keycloak-js'
 import { WebSocketLink } from 'apollo-link-ws'
 
 
@@ -278,12 +277,11 @@ var keycloak = Keycloak({
 })
 
 const wsLink = new WebSocketLink({
-  uri: `ws://localhost:5000/`,
+  uri: 'ws://localhost:5000/',
   options: {
     reconnect: true,
     connectionParams: {
-        Authorization: keycloak.token,
-        clientId: 'myapp'
+        Authorization: `Bearer ${keycloak.token}`
     }
 })
 ```

--- a/examples/lib/common.js
+++ b/examples/lib/common.js
@@ -5,7 +5,7 @@ const Keycloak = require('keycloak-connect')
 
 function configureKeycloak(app, graphqlPath) {
 
-  const keycloakConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, './config/keycloak.json')))
+  const keycloakConfig = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../config/keycloak.json')))
 
   const memoryStore = new session.MemoryStore()
 

--- a/examples/lib/getToken.js
+++ b/examples/lib/getToken.js
@@ -12,7 +12,7 @@ const settings = {
 tokenRequester(baseUrl, settings)
   .then((token) => {
     const headers = {
-      Authorization: `Bearer ${token}`, clientId: settings.client_id
+      Authorization: `Bearer ${token}`
     }
     console.log(JSON.stringify(headers))
   }).catch((err) => {

--- a/src/KeycloakSubscriptionHandler.ts
+++ b/src/KeycloakSubscriptionHandler.ts
@@ -73,7 +73,7 @@ export class KeycloakSubscriptionHandler {
       }
       return
     }
-    const token = this.getBearerTokenFromHeader(header, clientId)
+    const token = this.getBearerTokenFromHeader(header, this.keycloak.config.clientId)
     try {
       await this.keycloak.grantManager.validateToken(token, 'Bearer')
       //@ts-ignore

--- a/src/KeycloakSubscriptionHandler.ts
+++ b/src/KeycloakSubscriptionHandler.ts
@@ -66,7 +66,6 @@ export class KeycloakSubscriptionHandler {
                   || connectionParams.authorization
                   || connectionParams.Auth
                   || connectionParams.auth
-    const clientId = connectionParams.clientId
     if (!header) {
       if (this.protect === true) {
         throw new Error('Access Denied - missing Authorization field in connection parameters')

--- a/src/KeycloakTypings.ts
+++ b/src/KeycloakTypings.ts
@@ -190,6 +190,8 @@ declare namespace KeycloakConnect {
 
 
   interface Keycloak {
+    config: {[key: string]: any}
+
     grantManager: GrantManager
 
     /**

--- a/test/KeycloakSubscriptionHandler.test.ts
+++ b/test/KeycloakSubscriptionHandler.test.ts
@@ -13,6 +13,9 @@ test('onSubscriptionConnect throws if no keycloak provided', async t => {
 
 test('onSubscriptionConnect throws if no connectionParams Provided', async t => {
   const stubKeycloak = {
+    config: {
+      clientId: 'voyager-testing',
+    },
     grantManager: {
       validateToken: (token: string, type: 'string') => {
         return new Promise((resolve, reject) => {
@@ -31,6 +34,9 @@ test('onSubscriptionConnect throws if no connectionParams Provided', async t => 
 
 test('onSubscriptionConnect throws if no connectionParams is not an object', async t => {
   const stubKeycloak = {
+    config: {
+      clientId: 'voyager-testing',
+    },
     grantManager: {
       validateToken: (token: string, type: 'string') => {
         return new Promise((resolve, reject) => {
@@ -50,6 +56,9 @@ test('onSubscriptionConnect throws if no connectionParams is not an object', asy
 
 test('onSubscriptionConnect throws if no Auth provided', async t => {
   const stubKeycloak = {
+    config: {
+      clientId: 'voyager-testing',
+    },
     grantManager: {
       validateToken: (token: string, type: 'string') => {
         return new Promise((resolve, reject) => {
@@ -69,6 +78,9 @@ test('onSubscriptionConnect throws if no Auth provided', async t => {
 
 test('onSubscriptionConnect returns a token Object if the keycloak library considers it valid', async t => {
   const stubKeycloak = {
+    config: {
+      clientId: 'voyager-testing',
+    },
     grantManager: {
       validateToken: (token: string, type: 'string') => {
         return new Promise((resolve, reject) => {
@@ -89,6 +101,9 @@ test('onSubscriptionConnect returns a token Object if the keycloak library consi
 
 test('onSubscriptionConnect can also parse the token with lowercase \'bearer\'', async t => {
   const stubKeycloak = {
+    config: {
+      clientId: 'voyager-testing',
+    },
     grantManager: {
       validateToken: (token: string, type: 'string') => {
         return new Promise((resolve, reject) => {
@@ -109,6 +124,9 @@ test('onSubscriptionConnect can also parse the token with lowercase \'bearer\'',
 
 test('the token object will have hasRole, hasRealmRole and hasPermissions if the', async t => {
   const stubKeycloak = {
+    config: {
+      clientId: 'voyager-testing',
+    },
     grantManager: {
       validateToken: (token: string, type: 'string') => {
         return new Promise((resolve, reject) => {
@@ -133,6 +151,9 @@ test('the token object will have hasRole, hasRealmRole and hasPermissions if the
 test('If the keycloak token validation fails, then onSubscriptionConnect will throw', async t => {
   const errorMsg = 'token is invalid'
   const stubKeycloak = {
+    config: {
+      clientId: 'voyager-testing',
+    },
     grantManager: {
       validateToken: (token: string, type: 'string') => {
         return new Promise((resolve, reject) => {
@@ -156,6 +177,9 @@ test('If the keycloak token validation fails, then onSubscriptionConnect will th
 
 test('onSubscriptionConnect with {protect: false} does not throw if no connectionParams Provided', async t => {
   const stubKeycloak = {
+    config: {
+      clientId: 'voyager-testing',
+    },
     grantManager: {
       validateToken: (token: string, type: 'string') => {
         return new Promise((resolve, reject) => {
@@ -174,6 +198,9 @@ test('onSubscriptionConnect with {protect: false} does not throw if no connectio
 
 test('onSubscriptionConnect with {protect: false} does not throw if connectionParams is not an object', async t => {
   const stubKeycloak = {
+    config: {
+      clientId: 'voyager-testing',
+    },
     grantManager: {
       validateToken: (token: string, type: 'string') => {
         return new Promise((resolve, reject) => {
@@ -193,6 +220,9 @@ test('onSubscriptionConnect with {protect: false} does not throw if connectionPa
 
 test('onSubscriptionConnect with {protect: false} does not throw if no Auth provided', async t => {
   const stubKeycloak = {
+    config: {
+      clientId: 'voyager-testing',
+    },
     grantManager: {
       validateToken: (token: string, type: 'string') => {
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Background

When a keycloak token is created it's initialized with the token string and a clientId. e.g. `new Token(tokenString, clientId)`. Under the hood, in the regular keycloak middleware the Token is created using the clientId that would be found in the server keycloak config.

Example Config:

```
{
  "realm": "voyager-testing",
  "bearer-only": true,
  "auth-server-url": "http://localhost:8080/auth",
  "ssl-required": "none",
  "resource": "voyager-testing-bearer",
  "confidential-port": 0
}
```

The clientId here would be `voyager-testing-bearer`. This is passed into `new Token()` because it's needed for things like `token.hasRole` which is actually asking 'does this user have this particular role in that particular client?' 

Our client app would also have a separate public client where we normally wouldn't put roles on users.

## The Problem

We mistakenly had the subscription onConnect function reading a clientId value passed by the client in `connectionParams`. This value was then being used in the Keycloak Token creation. This leads to undesireable results because the user token was being created using the clientId passed by the client which could be anything really, but more than likely it would have been from their public keycloak client when it should have been the clientId on the server.

It turns out you can easily access the server clientId through `keycloak.config.clientId`.

Additionally, in a separate commit, I fixed a minor path issue in the examples.