### PR TITLE
chore: repo maintenance tasks

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,13 @@
+.circleci/
+.nyc_output/
+.vscode/
+# were not publishing source so we don't need source maps either
+dist/*.js.map
+examples/
+scripts/
+src/
+test/
+.gitignore
+renovate.json
+tsconfig.*
+tslint*

--- a/examples/config/docker-compose.yml
+++ b/examples/config/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   keycloak:
-    image: jboss/keycloak:3.4.3.Final
+    image: jboss/keycloak:8.0.1
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
These are two unrelated tasks but they might as well be thrown in here.

1. Update our examples to use the latest keycloak. All examples still working.
2. Add .npmignore to ensure unnecessary files aren't being added. Note: I chose not to include source or source maps in the final distribution.