### PR TITLE
fix: Add cors to examples

### DIFF
--- a/examples/basic.js
+++ b/examples/basic.js
@@ -6,7 +6,7 @@ const {
   KeycloakContext,
   KeycloakTypeDefs,
   KeycloakSchemaDirectives
-} = require('keycloak-connect-graphql')
+} = require('../')
 
 const app = express()
 

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,12 +1,12 @@
 const express = require('express')
 const { ApolloServer, gql } = require('apollo-server-express')
 const { configureKeycloak } = require('./lib/common')
-
+const cors = require("cors");
 const {
   KeycloakContext,
   KeycloakTypeDefs,
   KeycloakSchemaDirectives
-} = require('../')
+} = require('keycloak-connect-graphql')
 
 const app = express()
 
@@ -17,7 +17,7 @@ const { keycloak } = configureKeycloak(app, graphqlPath)
 
 // Ensure entire GraphQL Api can only be accessed by authenticated users
 app.use(graphqlPath, keycloak.protect())
-
+app.use(cors());
 const typeDefs = gql`
   type Query {
     hello: String @hasRole(role: "developer")

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/node": "10.17.13",
     "@types/sinon": "7.5.1",
     "ava": "2.4.0",
+    "cors": "^2.8.5",
     "coveralls": "3.0.9",
     "express": "4.17.1",
     "express-session": "1.17.0",
@@ -57,7 +58,8 @@
     "subscriptions-transport-ws": "0.9.16",
     "ts-node": "8.6.2",
     "tslint": "5.20.1",
-    "typescript": "3.7.5"
+    "typescript": "3.7.5",
+    "keycloak-connect-graphql": "0.2.4"
   },
   "peerDependencies": {
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "subscriptions-transport-ws": "0.9.16",
     "ts-node": "8.6.2",
     "tslint": "5.20.1",
-    "typescript": "3.7.5",
-    "keycloak-connect-graphql": "0.2.4"
+    "typescript": "3.7.5"
   },
   "peerDependencies": {
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0"


### PR DESCRIPTION
On taking clone, Running via your command in Read.me. I ran into an error with the import of KeyClockDef etc. I have updated that and now the application was running perfectly.. 
Import was 

const {
  KeycloakContext,
  KeycloakTypeDefs,
  KeycloakSchemaDirectives
} = require('../')
Now changed to as per description
const {
  KeycloakContext,
  KeycloakTypeDefs,
  KeycloakSchemaDirectives
} = require('keycloak-connect-graphql')

Also added CORS dependency for CORS request.