### PR TITLE
Implementation to return error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,31 @@ It also is possible to check for realm roles and application roles.
 * `hasRole('realm:admin')` will check the logged in user has the admin realm role
 * `hasRole('some-other-app:admin')` will check the loged in user has the admin realm role in a different application
 
+### Error Codes
+
+Library will return specific GraphQL errors to the client that can
+be differenciated by using error codes.
+
+Example response from GraphQL Server could look as follows:
+
+```json
+{
+   "errors":[
+      {
+        "message":"User is not authorized. Must have one of the following roles: [admin]",
+        "code": "FORBIDDEN"
+      }
+   ]
+}
+```
+
+Possible error codes: 
+
+- `NOT_AUTHENTICATED`: returned when user is not authorized to access API because it requires login
+- `FORBIDDEN`: returned when user do not have permission to perform operation 
+- `ACCESS_DENIED`: returned when client did not provided any authentication information. U
+sually means missconfiguration on the client
+
 ## Authentication and Authorization on Subscriptions
 
 The `KeycloakSubscriptionHandler` provides a way to validate incoming websocket connections to `SubscriptionServer` from [`subscriptions-transport-ws`](https://www.npmjs.com/package/subscriptions-transport-ws) for subscriptions and add the keycloak user token to the `context` in subscription resolvers.

--- a/README.md
+++ b/README.md
@@ -196,10 +196,8 @@ Example response from GraphQL Server could look as follows:
 
 Possible error codes: 
 
-- `NOT_AUTHENTICATED`: returned when user is not authorized to access API because it requires login
+- `UNAUTHENTICATED`: returned when user is not authenticated to access API because it requires login
 - `FORBIDDEN`: returned when user do not have permission to perform operation 
-- `ACCESS_DENIED`: returned when client did not provided any authentication information. U
-sually means missconfiguration on the client
 
 ## Authentication and Authorization on Subscriptions
 

--- a/src/KeycloakSubscriptionHandler.ts
+++ b/src/KeycloakSubscriptionHandler.ts
@@ -40,7 +40,7 @@ export class KeycloakSubscriptionHandler {
    * 
    * @param options 
    */
-  constructor (options: KeycloakSubscriptionHandlerOptions) {
+  constructor(options: KeycloakSubscriptionHandlerOptions) {
     if (!options || !options.keycloak) {
       throw new Error('missing keycloak instance in options')
     }
@@ -58,35 +58,31 @@ export class KeycloakSubscriptionHandler {
     if (!connectionParams || typeof connectionParams !== 'object') {
       if (this.protect === true) {
         const error: any = new Error(`Access Denied - missing connection parameters for Authentication`);
-        error.code = "ACCESS_DENIED"
+        error.code = "UNAUTHENTICATED"
         throw error
       }
       return
     }
     const header = connectionParams.Authorization
-                  || connectionParams.authorization
-                  || connectionParams.Auth
-                  || connectionParams.auth
+      || connectionParams.authorization
+      || connectionParams.Auth
+      || connectionParams.auth
     if (!header) {
       if (this.protect === true) {
-        const error: any = new Error(`Access Denied - missing Authorization field in connection parameters`);
-        error.code = "ACCESS_DENIED"
-        throw error
+        throw new Error(`Access Denied - missing Authorization field in connection parameters`);
       }
       return
     }
     try {
       // we don't use this naming style but
       // createGrant expects it
-      const grant = await this.keycloak.grantManager.createGrant({ 
-        access_token: this.getAccessTokenFromHeader(header) 
+      const grant = await this.keycloak.grantManager.createGrant({
+        access_token: this.getAccessTokenFromHeader(header)
       })
 
       return grant.access_token as unknown as Keycloak.Token
     } catch (e) {
-      const error: any = new Error(`Access Denied - ${e}`);
-      error.code = "ACCESS_DENIED"
-      throw error
+      throw new Error(`Access Denied - ${e}`);
     }
   }
 

--- a/src/KeycloakSubscriptionHandler.ts
+++ b/src/KeycloakSubscriptionHandler.ts
@@ -57,7 +57,9 @@ export class KeycloakSubscriptionHandler {
   public async onSubscriptionConnect(connectionParams: any, webSocket?: any, context?: any): Promise<Keycloak.Token | undefined> {
     if (!connectionParams || typeof connectionParams !== 'object') {
       if (this.protect === true) {
-        throw new Error('Access Denied - missing connection parameters for Authentication')
+        const error: any = new Error(`Access Denied - missing connection parameters for Authentication`);
+        error.code = "ACCESS_DENIED"
+        throw error
       }
       return
     }
@@ -67,7 +69,9 @@ export class KeycloakSubscriptionHandler {
                   || connectionParams.auth
     if (!header) {
       if (this.protect === true) {
-        throw new Error('Access Denied - missing Authorization field in connection parameters')
+        const error: any = new Error(`Access Denied - missing Authorization field in connection parameters`);
+        error.code = "ACCESS_DENIED"
+        throw error
       }
       return
     }
@@ -80,7 +84,9 @@ export class KeycloakSubscriptionHandler {
 
       return grant.access_token as unknown as Keycloak.Token
     } catch (e) {
-      throw new Error(`Access Denied - ${e}`)
+      const error: any = new Error(`Access Denied - ${e}`);
+      error.code = "ACCESS_DENIED"
+      throw error
     }
   }
 

--- a/src/directives/directiveResolvers.ts
+++ b/src/directives/directiveResolvers.ts
@@ -41,7 +41,7 @@ import { CONTEXT_KEY } from '../KeycloakContext'
 export const auth = (next: Function) => (root: any, args: any, context: any, info: any) => {
   if (!context[CONTEXT_KEY] || !context[CONTEXT_KEY].isAuthenticated()) {
     const error: any = new Error(`User not Authenticated`);
-    error.code = "NOT_AUTHENTICATED"
+    error.code = "UNAUTHENTICATED"
     throw error
   }
   return next(root, args, context, info)
@@ -97,7 +97,7 @@ export const auth = (next: Function) => (root: any, args: any, context: any, inf
 export const hasRole = (roles: Array<string>) => (next: Function) => (root: any, args: any, context: any, info: any) => {
   if (!context[CONTEXT_KEY] || !context[CONTEXT_KEY].isAuthenticated()) {
     const error: any = new Error(`User not Authenticated`);
-    error.code = "NOT_AUTHENTICATED"
+    error.code = "UNAUTHENTICATED"
     throw error
   }
 

--- a/src/directives/directiveResolvers.ts
+++ b/src/directives/directiveResolvers.ts
@@ -40,7 +40,9 @@ import { CONTEXT_KEY } from '../KeycloakContext'
  */
 export const auth = (next: Function) => (root: any, args: any, context: any, info: any) => {
   if (!context[CONTEXT_KEY] || !context[CONTEXT_KEY].isAuthenticated()) {
-    throw new Error(`User not Authenticated`)
+    const error: any = new Error(`User not Authenticated`);
+    error.code = "NOT_AUTHENTICATED"
+    throw error
   }
   return next(root, args, context, info)
 }
@@ -94,7 +96,9 @@ export const auth = (next: Function) => (root: any, args: any, context: any, inf
  */
 export const hasRole = (roles: Array<string>) => (next: Function) => (root: any, args: any, context: any, info: any) => {
   if (!context[CONTEXT_KEY] || !context[CONTEXT_KEY].isAuthenticated()) {
-    throw new Error(`User not Authenticated`)
+    const error: any = new Error(`User not Authenticated`);
+    error.code = "NOT_AUTHENTICATED"
+    throw error
   }
 
   if (typeof roles === 'string') {
@@ -111,7 +115,9 @@ export const hasRole = (roles: Array<string>) => (next: Function) => (root: any,
   }
 
   if (!foundRole) {
-    throw new Error(`User is not authorized. Must have one of the following roles: [${roles}]`)
+    const error: any = new Error(`User is not authorized. Must have one of the following roles: [${roles}]`);
+    error.code = "FORBIDDEN"
+    throw error
   }
 
   return next(root, args, context, info)


### PR DESCRIPTION
## Motivation

Return error codes for all programatic errors 

Possible error codes: 

- `NOT_AUTHENTICATED`: returned when user is not authorized to access API because it requires login
- `FORBIDDEN`: returned when user do not have permission to perform operation 
- `ACCESS_DENIED`: returned when client did not provided any authentication information. U
sually means misconfiguration on the client. I'm not sure about this error code but is seems to be mixture of missconfiguration and runtime errors

## Verification

Sample app should return extra value now:


```json
{
   "errors":[
      {
        "message":"User is not authorized. Must have one of the following roles: [admin]",
        "code": "FORBIDDEN"
      }
   ]
}
```